### PR TITLE
ROM loading and SDL frontend

### DIFF
--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -22,7 +22,6 @@ const STACK_BASE: u16 = 0x0100;
 const STACK_INIT: u8 = 0xfd;
 
 const DECIMAL_ENABLED: bool = false;
-const DEBUG: bool = false;
 
 pub struct CPU {
     // Registers
@@ -35,6 +34,7 @@ pub struct CPU {
     pc: u16, // Program counter
     wait_cycles: u32,
     cycles: usize,
+    pub log: bool,
 
     memory: Box<dyn Memory>,
 }
@@ -50,6 +50,7 @@ impl CPU {
             pc: 0,
             wait_cycles: 0,
             cycles: 0,
+            log: false,
             memory,
         }
     }
@@ -81,7 +82,7 @@ impl CPU {
         let op = INSTRUCTIONS
             .get(&opcode)
             .expect("Unimplemented instruction");
-        let log = if DEBUG {
+        let log = if self.log {
             Some(self.format_step(op))
         } else {
             None

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod mmu;
 pub mod ram;
+pub mod rom;
 
 pub trait Memory {
     fn read(&mut self, addr: u16) -> u8;

--- a/memory/src/mmu.rs
+++ b/memory/src/mmu.rs
@@ -59,7 +59,7 @@ impl MMU {
     }
 
     pub fn map_ram(&mut self, start: u16, end: u16) {
-        self.map_ram_mirrored(start, end, end - start);
+        self.map_ram_mirrored(start, end, end - start + 1);
     }
 
     fn access(&self, addr: u16) -> Result<(u16, &Rc<RefCell<dyn Memory>>), &'static str> {

--- a/memory/src/mmu.rs
+++ b/memory/src/mmu.rs
@@ -46,7 +46,7 @@ impl MMU {
     }
 
     pub fn map(&mut self, start: u16, end: u16, memory: Rc<RefCell<dyn Memory>>) {
-        self.map_mirrored(start, end, end - start, memory);
+        self.map_mirrored(start, end, end - start + 1, memory);
     }
 
     pub fn map_ram_mirrored(&mut self, start: u16, end: u16, size: u16) {

--- a/memory/src/rom.rs
+++ b/memory/src/rom.rs
@@ -1,0 +1,32 @@
+use crate::Memory;
+
+pub struct ROM {
+  pub memory: Vec<u8>,
+  pub start: u16,
+}
+
+impl ROM {
+  pub fn new(size: u16, start: u16) -> Self {
+    ROM {
+      memory: vec![0; size as usize],
+      start,
+    }
+  }
+}
+
+impl Memory for ROM {
+  fn read(&mut self, addr: u16) -> u8 {
+    self.memory[(addr - self.start) as usize]
+  }
+
+  fn peek(&self, addr: u16) -> u8 {
+    self.memory[(addr - self.start) as usize]
+  }
+
+  fn write(&mut self, addr: u16, data: u8) {
+    panic!(format!(
+      "attempted to write {:X} to address {:X} in ROM",
+      data, addr
+    ))
+  }
+}

--- a/nes/src/cartridge/cartridge_metadata.rs
+++ b/nes/src/cartridge/cartridge_metadata.rs
@@ -1,0 +1,117 @@
+// https://wiki.nesdev.com/w/index.php/NES_2.0#Header
+pub struct CartridgeMetadata {
+    pub n_prg_banks: u16,
+    pub n_chr_banks: u16,
+    pub hardwired_mirroring: Mirroring,
+    pub has_battery: bool,
+    pub has_trainer: bool,
+    pub mapper_num: u16,
+
+    // Uncommon features
+    pub submapper_num: u16,
+    pub console_type: ConsoleType,
+    pub prg_ram_shifts: u8,
+    pub prg_nvram_shifts: u8,
+    pub chr_ram_shifts: u8,
+    pub chr_nvram_shifts: u8,
+    pub timing: ClockTiming,
+    pub vs_system_type: u8,
+    pub extended_console_type: u8,
+    pub n_misc_roms: u8,
+    pub default_expansion_device: u8,
+}
+
+impl CartridgeMetadata {
+    pub fn from_header(header: Vec<u8>) -> Result<Self, &'static str> {
+        if header[0..=3] != [b'N', b'E', b'S', 0x1A] {
+            return Err("header does not begin with NES<EOF> identifier");
+        }
+
+        let n_prg_banks = (((header[9] & 0x0F) as u16) << 8) | (header[4] as u16);
+        let n_chr_banks = (((header[9] & 0xF0) as u16) << 4) | (header[5] as u16);
+
+        let hardwired_mirroring = if ((header[6] >> 3) & 1) == 1 {
+            Mirroring::FourScreen
+        } else {
+            match header[6] & 1 {
+                0 => Mirroring::Horizontal,
+                _ => Mirroring::Vertical,
+            }
+        };
+
+        let has_battery = ((header[6] >> 1) & 1) == 1;
+        let has_trainer = ((header[6] >> 2) & 1) == 1;
+
+        let mapper_num = ((header[6] >> 4) as u16)
+            | ((header[7] & 0xF0) as u16)
+            | (((header[8] & 0x0F) as u16) << 8);
+        let submapper_num = (header[8] >> 4) as u16;
+
+        let console_type = match header[7] & 0b11 {
+            0 => ConsoleType::NESFamicom,
+            1 => ConsoleType::VsSystem,
+            2 => ConsoleType::Playchoice10,
+            _ => ConsoleType::Extended,
+        };
+
+        let prg_ram_shifts = header[10] & 0x0F;
+        let prg_nvram_shifts = (header[10] & 0xF0) >> 4;
+        let chr_ram_shifts = header[11] & 0x0F;
+        let chr_nvram_shifts = (header[11] & 0xF0) >> 4;
+
+        let timing = match header[12] & 0b11 {
+            0 => ClockTiming::NTSC,
+            1 => ClockTiming::PAL,
+            2 => ClockTiming::MultiRegion,
+            _ => ClockTiming::Dendy,
+        };
+
+        // TODO: These can be enums
+        let vs_system_type = header[13];
+        let extended_console_type = header[13] & 0x0F;
+
+        let n_misc_roms = header[14] & 0b11;
+        let default_expansion_device = header[14] & 0b11_1111;
+
+        Ok(Self {
+            n_prg_banks,
+            n_chr_banks,
+            hardwired_mirroring,
+            has_battery,
+            has_trainer,
+            mapper_num,
+            submapper_num,
+            console_type,
+            prg_ram_shifts,
+            prg_nvram_shifts,
+            chr_ram_shifts,
+            chr_nvram_shifts,
+            timing,
+            vs_system_type,
+            extended_console_type,
+            n_misc_roms,
+            default_expansion_device,
+        })
+    }
+}
+
+enum Mirroring {
+    Horizontal,
+    Vertical,
+    SingleScreen,
+    FourScreen,
+}
+
+enum ConsoleType {
+    NESFamicom,
+    VsSystem,
+    Playchoice10,
+    Extended,
+}
+
+enum ClockTiming {
+    NTSC,
+    PAL,
+    MultiRegion,
+    Dendy,
+}

--- a/nes/src/cartridge/cartridge_metadata.rs
+++ b/nes/src/cartridge/cartridge_metadata.rs
@@ -95,21 +95,22 @@ impl CartridgeMetadata {
     }
 }
 
-enum Mirroring {
+#[derive(Copy, Clone)]
+pub enum Mirroring {
     Horizontal,
     Vertical,
     SingleScreen,
     FourScreen,
 }
 
-enum ConsoleType {
+pub enum ConsoleType {
     NESFamicom,
     VsSystem,
     Playchoice10,
     Extended,
 }
 
-enum ClockTiming {
+pub enum ClockTiming {
     NTSC,
     PAL,
     MultiRegion,

--- a/nes/src/cartridge/mapper/mapper0.rs
+++ b/nes/src/cartridge/mapper/mapper0.rs
@@ -1,0 +1,60 @@
+use crate::cartridge::Mapper;
+use memory::rom::ROM;
+use memory::Memory;
+
+pub struct Mapper0 {
+    n_prg_banks: u16,
+    n_chr_banks: u16,
+    prg_rom: ROM,
+    chr_rom: ROM,
+}
+
+impl Mapper for Mapper0 {}
+
+impl Mapper0 {
+    pub fn new(n_prg_banks: u16, n_chr_banks: u16, prg_data: Vec<u8>, chr_data: Vec<u8>) -> Self {
+        Self {
+            n_prg_banks,
+            n_chr_banks,
+            prg_rom: ROM {
+                memory: prg_data,
+                start: 0x8000,
+            },
+            chr_rom: ROM {
+                memory: chr_data,
+                start: 0x0000,
+            },
+        }
+    }
+}
+
+impl Memory for Mapper0 {
+    fn read(&mut self, addr: u16) -> u8 {
+        if addr <= 0x1FFF {
+            self.chr_rom.read(addr % (self.n_chr_banks * 0x2000))
+        } else {
+            self.prg_rom
+                .read(((addr - 0x8000) % (self.n_prg_banks * 0x4000)) + 0x8000)
+        }
+    }
+
+    fn peek(&self, addr: u16) -> u8 {
+        if addr <= 0x1FFF {
+            self.chr_rom.peek(addr % (self.n_chr_banks * 0x2000))
+        } else {
+            self.prg_rom
+                .peek(((addr - 0x8000) % (self.n_prg_banks * 0x4000)) + 0x8000)
+        }
+    }
+
+    fn write(&mut self, addr: u16, data: u8) {
+        if addr <= 0x1FFF {
+            self.chr_rom.write(addr % (self.n_chr_banks * 0x2000), data)
+        } else {
+            self.prg_rom.write(
+                ((addr - 0x8000) % (self.n_prg_banks * 0x4000)) + 0x8000,
+                data,
+            )
+        }
+    }
+}

--- a/nes/src/cartridge/mapper/mod.rs
+++ b/nes/src/cartridge/mapper/mod.rs
@@ -1,0 +1,10 @@
+use crate::cartridge::Mirroring;
+use memory::Memory;
+
+pub mod mapper0;
+
+pub trait Mapper: Memory {
+    fn get_nametable_mirroring(&self) -> Option<Mirroring> {
+        None // Unless otherwise specified, mirroring is hard-wired
+    }
+}

--- a/nes/src/cartridge/mod.rs
+++ b/nes/src/cartridge/mod.rs
@@ -1,0 +1,30 @@
+use memory::Memory;
+use std::fs::File;
+use std::io::prelude::*;
+
+mod cartridge_metadata;
+use cartridge_metadata::CartridgeMetadata;
+
+pub struct Cartridge {
+    meta: CartridgeMetadata,
+    mapper: Box<dyn Mapper>,
+}
+
+impl Cartridge {
+    pub fn from_file(file: File) -> Result<Self, &'static str> {
+        let mut bytes = file.bytes();
+        let header = match bytes.by_ref().take(0x10).collect() {
+            Ok(header) => header,
+            Err(_) => return Err("hit EOF while reading file header"),
+        };
+        let meta = CartridgeMetadata::from_header(header)?;
+
+        let mapper = match meta.mapper_num {
+            _ => return Err(format!("mapper {} is not supported", meta.mapper_num)),
+        }
+
+        Ok(Self { meta, mapper })
+    }
+}
+
+trait Mapper: Memory {}

--- a/nes/src/cartridge/mod.rs
+++ b/nes/src/cartridge/mod.rs
@@ -4,6 +4,11 @@ use std::io::prelude::*;
 
 mod cartridge_metadata;
 use cartridge_metadata::CartridgeMetadata;
+pub use cartridge_metadata::Mirroring;
+
+mod mapper;
+use mapper::*;
+use mapper0::Mapper0;
 
 pub struct Cartridge {
     meta: CartridgeMetadata,
@@ -19,12 +24,42 @@ impl Cartridge {
         };
         let meta = CartridgeMetadata::from_header(header)?;
 
-        let mapper = match meta.mapper_num {
-            _ => return Err(format!("mapper {} is not supported", meta.mapper_num)),
-        }
+        let prg_data = bytes
+            .by_ref()
+            .take(0x4000 * (meta.n_prg_banks as usize))
+            .map(|x| x.unwrap())
+            .collect::<Vec<u8>>();
+        let chr_data = bytes
+            .by_ref()
+            .take(0x2000 * (meta.n_chr_banks as usize))
+            .map(|x| x.unwrap())
+            .collect::<Vec<u8>>();
+
+        let mapper = Box::from(match meta.mapper_num {
+            0 => Mapper0::new(meta.n_prg_banks, meta.n_chr_banks, prg_data, chr_data),
+            _ => return Err("unsupported mapper"),
+        });
 
         Ok(Self { meta, mapper })
     }
+
+    pub fn get_nametable_mirroring(&self) -> Mirroring {
+        self.mapper
+            .get_nametable_mirroring()
+            .unwrap_or(self.meta.hardwired_mirroring)
+    }
 }
 
-trait Mapper: Memory {}
+impl Memory for Cartridge {
+    fn read(&mut self, addr: u16) -> u8 {
+        self.mapper.read(addr)
+    }
+
+    fn peek(&self, addr: u16) -> u8 {
+        self.mapper.peek(addr)
+    }
+
+    fn write(&mut self, addr: u16, data: u8) {
+        self.mapper.write(addr, data);
+    }
+}

--- a/nes/src/cartridge/mod.rs
+++ b/nes/src/cartridge/mod.rs
@@ -11,11 +11,18 @@ use mapper::*;
 use mapper0::Mapper0;
 
 pub struct Cartridge {
-    meta: CartridgeMetadata,
-    mapper: Box<dyn Mapper>,
+    meta: Option<CartridgeMetadata>,
+    mapper: Option<Box<dyn Mapper>>,
 }
 
 impl Cartridge {
+    pub fn new() -> Self {
+        Self {
+            meta: None,
+            mapper: None,
+        }
+    }
+
     pub fn from_file(file: File) -> Result<Self, &'static str> {
         let mut bytes = file.bytes();
         let header = match bytes.by_ref().take(0x10).collect() {
@@ -24,42 +31,62 @@ impl Cartridge {
         };
         let meta = CartridgeMetadata::from_header(header)?;
 
-        let prg_data = bytes
-            .by_ref()
-            .take(0x4000 * (meta.n_prg_banks as usize))
-            .map(|x| x.unwrap())
-            .collect::<Vec<u8>>();
-        let chr_data = bytes
-            .by_ref()
-            .take(0x2000 * (meta.n_chr_banks as usize))
-            .map(|x| x.unwrap())
-            .collect::<Vec<u8>>();
+        let prg_size = 0x4000 * (meta.n_prg_banks as usize);
+        let prg_data = match bytes.by_ref().take(prg_size).collect() {
+            Ok(data) => data,
+            Err(_) => return Err("hit EOF while reading program ROM"),
+        };
+        let chr_size = 0x2000 * (meta.n_chr_banks as usize);
+        let chr_data = match bytes.by_ref().take(chr_size).collect() {
+            Ok(data) => data,
+            Err(_) => return Err("hit EOF while reading character ROM"),
+        };
 
         let mapper = Box::from(match meta.mapper_num {
             0 => Mapper0::new(meta.n_prg_banks, meta.n_chr_banks, prg_data, chr_data),
             _ => return Err("unsupported mapper"),
         });
 
-        Ok(Self { meta, mapper })
+        Ok(Self {
+            meta: Some(meta),
+            mapper: Some(mapper),
+        })
     }
 
     pub fn get_nametable_mirroring(&self) -> Mirroring {
-        self.mapper
-            .get_nametable_mirroring()
-            .unwrap_or(self.meta.hardwired_mirroring)
+        let default = if let Some(some_meta) = &self.meta {
+            some_meta.hardwired_mirroring
+        } else {
+            Mirroring::Horizontal
+        };
+        if let Some(some_mapper) = &self.mapper {
+            some_mapper.get_nametable_mirroring().unwrap_or(default)
+        } else {
+            default
+        }
     }
 }
 
 impl Memory for Cartridge {
     fn read(&mut self, addr: u16) -> u8 {
-        self.mapper.read(addr)
+        if let Some(some_mapper) = &mut self.mapper {
+            some_mapper.read(addr)
+        } else {
+            0x00
+        }
     }
 
     fn peek(&self, addr: u16) -> u8 {
-        self.mapper.peek(addr)
+        if let Some(some_mapper) = &self.mapper {
+            some_mapper.peek(addr)
+        } else {
+            0x00
+        }
     }
 
     fn write(&mut self, addr: u16, data: u8) {
-        self.mapper.write(addr, data);
+        if let Some(some_mapper) = &mut self.mapper {
+            some_mapper.write(addr, data);
+        }
     }
 }

--- a/nes/src/lib.rs
+++ b/nes/src/lib.rs
@@ -1,40 +1,86 @@
+mod cartridge;
+mod nametable_memory;
+
+use crate::cartridge::Cartridge;
+use crate::nametable_memory::NametableMemory;
 use cpu::CPU;
 use memory::mmu::MMU;
 use ppu::PPU;
 use std::cell::RefCell;
+use std::fs::File;
 use std::rc::Rc;
 
 pub struct NES {
     cpu: Rc<RefCell<CPU>>,
     ppu: Rc<RefCell<PPU>>,
+    cart: Rc<RefCell<Cartridge>>,
 }
 
 impl NES {
     pub fn new() -> Self {
+        let cart = Rc::new(RefCell::new(Cartridge::new()));
+
         // https://wiki.nesdev.com/w/index.php/PPU_memory_map
         let mut ppu_mmu = MMU::new();
-        // ppu_mmu.map(&cart, 0x0000, 0x1FFF); // Pattern tables
-        ppu_mmu.map_ram_mirrored(0x2000, 0x3EFF, 0x0400); // Nametables
+        ppu_mmu.map(0x0000, 0x1FFF, cart.clone()); // Pattern tables
+        ppu_mmu.map(
+            0x2000,
+            0x3EFF,
+            Rc::new(RefCell::new(NametableMemory::new(cart.clone()))),
+        );
         ppu_mmu.map_ram_mirrored(0x3F00, 0x3FFF, 0x0020); // Palette RAM indices
         let ppu = Rc::new(RefCell::new(PPU::new(Box::from(ppu_mmu))));
-        ppu.borrow_mut().reset();
 
         // https://wiki.nesdev.com/w/index.php/CPU_memory_map
         let mut cpu_mmu = MMU::new();
         cpu_mmu.map_ram_mirrored(0x0000, 0x1FFF, 0x0800);
-        cpu_mmu.map_mirrored(0x2000, 0x3FFF, 0x0008, ppu.clone());
-        // cpu_mmu.map(&apu_io_reg, 0x4000, 0x401F);
-        // cpu_mmu.map(&cart, 0x4020, 0xFFFF);
+        cpu_mmu.map_mirrored(0x2000, 0x3FFF, 0x0008, ppu.clone()); // PPU registers
+        cpu_mmu.map(0x4014, 0x4014, ppu.clone()); // OAMDMA
+                                                  // cpu_mmu.map(&apu_io_reg, 0x4000, 0x401F);
+        cpu_mmu.map(0x4020, 0xFFFF, cart.clone());
         let cpu = Rc::new(RefCell::new(CPU::new(Box::from(cpu_mmu))));
         cpu.borrow_mut().reset();
 
         ppu.borrow_mut().set_dma(cpu.clone());
 
-        Self { cpu, ppu }
+        Self { cpu, ppu, cart }
+    }
+
+    /// Load a rom from a file and reset the system, returning whether it succeeded
+    pub fn load_rom(&mut self, file: File) -> Result<(), &'static str> {
+        match Cartridge::from_file(file) {
+            Ok(new_cart) => {
+                self.cart.replace(new_cart);
+                self.cpu.borrow_mut().reset();
+                self.ppu.borrow_mut().reset();
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn unload_rom(&mut self) {
+        self.cart.replace(Cartridge::new());
     }
 
     pub fn tick(&mut self) {
-        self.cpu.borrow_mut().tick();
+        self.ppu.borrow_mut().frame_ready = false;
+        if let Some(log) = self.cpu.borrow_mut().tick() {
+            println!("{}", log);
+        }
         self.ppu.borrow_mut().cpu_cycle();
+        if self.ppu.borrow().nmi {
+            self.ppu.borrow_mut().nmi = false;
+            self.cpu.borrow_mut().nmi();
+        }
+    }
+
+    pub fn get_new_frame(&self) -> Option<[[u8; 256]; 240]> {
+        let ppu = self.ppu.borrow();
+        if ppu.frame_ready {
+            Some(ppu.framebuffer)
+        } else {
+            None
+        }
     }
 }

--- a/nes/src/nametable_memory.rs
+++ b/nes/src/nametable_memory.rs
@@ -1,0 +1,54 @@
+use crate::cartridge::Cartridge;
+use crate::cartridge::Mirroring;
+use memory::ram::RAM;
+use memory::Memory;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub struct NametableMemory {
+  cart: Rc<RefCell<Cartridge>>,
+  memory: RAM,
+}
+
+impl NametableMemory {
+  pub fn new(cart: Rc<RefCell<Cartridge>>) -> Self {
+    Self {
+      cart,
+      memory: RAM::new(0x400 * 4, 0x0000),
+    }
+  }
+
+  fn mirror(&self, addr: u16) -> u16 {
+    // Adapted from a clever approach by daniel5151
+    let mut _addr = addr;
+    if _addr > 0x3000 {
+      _addr -= 0x1000;
+    }
+    let mut fix_4s = 0;
+    let nt_mirroring = match self.cart.borrow().get_nametable_mirroring() {
+      Mirroring::Vertical => [0, 1, 0, 1],
+      Mirroring::Horizontal => [0, 0, 1, 1],
+      Mirroring::FourScreen => {
+        fix_4s = 0x2000;
+        [0, 1, 2, 3]
+      }
+      Mirroring::SingleScreen => [0, 0, 0, 0],
+    };
+
+    nt_mirroring[((_addr - 0x2000) / 0x400) as usize] * 0x400 + (_addr % 0x400) + fix_4s
+  }
+}
+
+impl Memory for NametableMemory {
+  fn read(&mut self, addr: u16) -> u8 {
+    self.memory.read(self.mirror(addr))
+  }
+
+  fn peek(&self, addr: u16) -> u8 {
+    self.memory.peek(self.mirror(addr))
+  }
+
+  fn write(&mut self, addr: u16, data: u8) {
+    self.memory.write(self.mirror(addr), data);
+  }
+}

--- a/nes/tests/nestest.rs
+++ b/nes/tests/nestest.rs
@@ -47,6 +47,7 @@ fn nestest_cpu() {
     );
     cpu_mmu.write_u16(0xFFFC, 0xC000);
     let mut cpu = CPU::new(Box::from(cpu_mmu));
+    cpu.log = true;
     cpu.reset();
 
     let log_file = File::open(log_path).unwrap();

--- a/ppu/src/lib.rs
+++ b/ppu/src/lib.rs
@@ -50,7 +50,14 @@ impl PPU {
     }
 
     pub fn reset(&mut self) {
-        // todo!()
+        self.registers.reset();
+        self.scan = Scan::new();
+        self.bg_data = BackgroundData::new();
+        self.dma_option = None;
+        self.dma_request = None;
+        self.framebuffer = [[0; 256]; 240];
+        self.nmi = false;
+        self.frame_ready = false;
     }
 
     pub fn tick(&mut self) {
@@ -297,8 +304,6 @@ impl Memory for PPU {
                 self.registers
                     .ppustatus
                     .remove(StatusRegister::VBLANK_STARTED);
-                // TODO: NMI
-                // self.nmi = true;
 
                 high_three | (self.registers.bus_latch & 0b000_11111)
             }
@@ -377,8 +382,7 @@ impl Memory for PPU {
                     .ppustatus
                     .contains(StatusRegister::VBLANK_STARTED);
                 if vblank_set && nmi_rising_edge {
-                    // TODO: NMI
-                    // self.nmi = true;
+                    self.nmi = true;
                 }
                 self.registers
                     .temp_addr

--- a/ppu/src/scan.rs
+++ b/ppu/src/scan.rs
@@ -61,7 +61,7 @@ impl Scan {
     }
 
     pub fn on_bg_fetch_cycle(&self) -> bool {
-        1 <= self.cycle && self.cycle <= 256
+        (1 <= self.cycle && self.cycle <= 256) || (321 <= self.cycle && self.cycle <= 336)
     }
 
     pub fn on_spr_fetch_cycle(&self) -> bool {

--- a/sdl-ui/Cargo.toml
+++ b/sdl-ui/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sdl-ui"
+version = "0.1.0"
+authors = ["Henry Sloan <henryksloan@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+nes = { path = "../nes" }
+cpu = { path = "../cpu" }
+memory = { path = "../memory" }
+sdl2 = "0.34"
+rand = "0.8.3"
+
+# [profile.release]
+# debug = true

--- a/sdl-ui/src/main.rs
+++ b/sdl-ui/src/main.rs
@@ -1,0 +1,120 @@
+use nes;
+use nes::NES;
+
+use std::env;
+use std::fs::File;
+use std::process;
+
+use sdl2::event::Event;
+use sdl2::keyboard::Keycode;
+use sdl2::pixels::PixelFormatEnum;
+
+const COLORS: &'static [i32] = &[
+    0x666666, 0x002A88, 0x1412A7, 0x3B00A4, 0x5C007E, 0x6E0040, 0x6C0600, 0x561D00, 0x333500,
+    0x0B4800, 0x005200, 0x004F08, 0x00404D, 0x000000, 0x000000, 0x000000, 0xADADAD, 0x155FD9,
+    0x4240FF, 0x7527FE, 0xA01ACC, 0xB71E7B, 0xB53120, 0x994E00, 0x6B6D00, 0x388700, 0x0C9300,
+    0x008F32, 0x007C8D, 0x000000, 0x000000, 0x000000, 0xFFFEFF, 0x64B0FF, 0x9290FF, 0xC676FF,
+    0xF36AFF, 0xFE6ECC, 0xFE8170, 0xEA9E22, 0xBCBE00, 0x88D800, 0x5CE430, 0x45E082, 0x48CDDE,
+    0x4F4F4F, 0x000000, 0x000000, 0xFFFEFF, 0xC0DFFF, 0xD3D2FF, 0xE8C8FF, 0xFBC2FF, 0xFEC4EA,
+    0xFECCC5, 0xF7D8A5, 0xE4E594, 0xCFEF96, 0xBDF4AB, 0xB3F3CC, 0xB5EBF2, 0xB8B8B8, 0x000000,
+    0x000000,
+];
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("usage: {} <NES ROM file>", args[0]);
+        process::exit(1);
+    }
+
+    let file = File::open(&args[1]).unwrap_or_else(|err| {
+        println!("failed to read file: {}", err);
+        process::exit(1);
+    });
+
+    let mut nes = NES::new();
+    nes.load_rom(file).unwrap_or_else(|err| {
+        println!("failed to load ROM: {}", err);
+        process::exit(1);
+    });
+
+    let sdl_context = sdl2::init().unwrap();
+    let video_subsystem = sdl_context.video().unwrap();
+    let window = video_subsystem
+        .window("KindNES", (256.0 * 3.0) as u32, (240.0 * 3.0) as u32)
+        .position_centered()
+        .build()
+        .unwrap();
+
+    let mut canvas = window.into_canvas().present_vsync().build().unwrap();
+    let mut event_pump = sdl_context.event_pump().unwrap();
+    canvas.set_scale(3.0, 3.0).unwrap();
+
+    let creator = canvas.texture_creator();
+    let mut texture = creator
+        .create_texture_target(PixelFormatEnum::RGB24, 256, 240)
+        .unwrap();
+
+    let mut screen_buff = [0u8; 256 * 240 * 3];
+
+    use std::time::Instant;
+    let mut now = Instant::now();
+    let mut frame_count = 0;
+    let frames_per_rate_check = 60;
+    let checks_per_rate_report = 2;
+    let get_fps = |micros| (1f32 / ((micros / frames_per_rate_check) as f32 * 0.000001)) as u32;
+    loop {
+        nes.tick();
+
+        for event in event_pump.poll_iter() {
+            match event {
+                Event::Quit { .. }
+                | Event::KeyDown {
+                    keycode: Some(Keycode::Escape),
+                    ..
+                } => std::process::exit(0),
+                _ => {}
+            }
+        }
+
+        if let Some(framebuffer) = nes.get_new_frame() {
+            if (frame_count + 1) % frames_per_rate_check == 0 {
+                if (frame_count + 1) % (frames_per_rate_check * checks_per_rate_report) == 0 {
+                    canvas
+                        .window_mut()
+                        .set_title(
+                            &format!("KindNES | {} fps", get_fps(now.elapsed().as_micros()))[..],
+                        )
+                        .unwrap();
+                }
+                now = Instant::now();
+            }
+            frame_count += 1;
+
+            let mut pixel_i = 0;
+            let mut update = false;
+            for y in 0..240 {
+                for x in 0..256 {
+                    let color = framebuffer[y][x];
+                    let c = COLORS[(color as usize) % 64];
+                    let (r, g, b) = ((c >> 16) as u8, ((c >> 8) & 0xFF) as u8, (c & 0xFF) as u8);
+                    if screen_buff[pixel_i + 0] != r
+                        || screen_buff[pixel_i + 1] != g
+                        || screen_buff[pixel_i + 2] != b
+                    {
+                        screen_buff[pixel_i + 0] = r;
+                        screen_buff[pixel_i + 1] = g;
+                        screen_buff[pixel_i + 2] = b;
+                        update = true;
+                    }
+                    pixel_i += 3;
+                }
+            }
+            if update {
+                texture.update(None, &screen_buff, 256 * 3).unwrap();
+                canvas.copy(&texture, None, None).unwrap();
+                canvas.present();
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added a `Cartridge` struct that reads and owns cartridge data
    - A `CartridgeMetadata` struct handles the parsing and storage of header data
        - It currently holds lots of unused data and structs, which will eventually allow for huge extensibility
    - A `Mapper` trait as a general interface to memory mapping
        - Currently just has simple features like nametable mirror fetching, but it should provide a general, extensible interface to any memory access
        - Added Mapper0 implementation
- Added cartridge loading to the `NES` struct
    - The default cartridge is holds `None` in place of the mapper and metadata, with memory accesses returning 0
- Added a working SDL frontend
    - Reports FPS every 120 frames (~2 seconds) in the window title
    - Only draws frames when the PPU says one is ready (VBlank start)