### PR TITLE
Standard NES controller support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.85"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
+checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
 
 [[package]]
 name = "memory"
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom",
 ]

--- a/memory/src/rom.rs
+++ b/memory/src/rom.rs
@@ -1,32 +1,32 @@
 use crate::Memory;
 
 pub struct ROM {
-  pub memory: Vec<u8>,
-  pub start: u16,
+    pub memory: Vec<u8>,
+    pub start: u16,
 }
 
 impl ROM {
-  pub fn new(size: u16, start: u16) -> Self {
-    ROM {
-      memory: vec![0; size as usize],
-      start,
+    pub fn new(size: u16, start: u16) -> Self {
+        ROM {
+            memory: vec![0; size as usize],
+            start,
+        }
     }
-  }
 }
 
 impl Memory for ROM {
-  fn read(&mut self, addr: u16) -> u8 {
-    self.memory[(addr - self.start) as usize]
-  }
+    fn read(&mut self, addr: u16) -> u8 {
+        self.memory[(addr - self.start) as usize]
+    }
 
-  fn peek(&self, addr: u16) -> u8 {
-    self.memory[(addr - self.start) as usize]
-  }
+    fn peek(&self, addr: u16) -> u8 {
+        self.memory[(addr - self.start) as usize]
+    }
 
-  fn write(&mut self, addr: u16, data: u8) {
-    panic!(format!(
-      "attempted to write {:X} to address {:X} in ROM",
-      data, addr
-    ))
-  }
+    fn write(&mut self, addr: u16, data: u8) {
+        panic!(format!(
+            "attempted to write {:X} to address {:X} in ROM",
+            data, addr
+        ))
+    }
 }

--- a/nes/src/controllers/mod.rs
+++ b/nes/src/controllers/mod.rs
@@ -1,0 +1,5 @@
+mod no_controller;
+mod standard_controller;
+
+pub use self::no_controller::NoController;
+pub use self::standard_controller::StandardController;

--- a/nes/src/controllers/mod.rs
+++ b/nes/src/controllers/mod.rs
@@ -1,5 +1,13 @@
 mod no_controller;
 mod standard_controller;
 
+use memory::Memory;
+
+pub trait Controller: Memory {
+    fn is_controller_1(&self) -> bool;
+    fn get_shift_strobe(&self) -> bool;
+    fn set_state_shift(&mut self, val: u8);
+}
+
 pub use self::no_controller::NoController;
 pub use self::standard_controller::StandardController;

--- a/nes/src/controllers/no_controller.rs
+++ b/nes/src/controllers/no_controller.rs
@@ -1,0 +1,21 @@
+use memory::Memory;
+
+pub struct NoController {}
+
+impl NoController {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Memory for NoController {
+    fn read(&mut self, _: u16) -> u8 {
+        0
+    }
+
+    fn peek(&self, _: u16) -> u8 {
+        0
+    }
+
+    fn write(&mut self, _: u16, _: u8) {}
+}

--- a/nes/src/controllers/no_controller.rs
+++ b/nes/src/controllers/no_controller.rs
@@ -1,3 +1,4 @@
+use crate::controllers::Controller;
 use memory::Memory;
 
 pub struct NoController {}
@@ -6,6 +7,18 @@ impl NoController {
     pub fn new() -> Self {
         Self {}
     }
+}
+
+impl Controller for NoController {
+    fn is_controller_1(&self) -> bool {
+        false
+    }
+
+    fn get_shift_strobe(&self) -> bool {
+        false
+    }
+
+    fn set_state_shift(&mut self, _: u8) {}
 }
 
 impl Memory for NoController {

--- a/nes/src/controllers/standard_controller.rs
+++ b/nes/src/controllers/standard_controller.rs
@@ -1,3 +1,4 @@
+use crate::controllers::Controller;
 use memory::Memory;
 
 // https://wiki.nesdev.com/w/index.php/Standard_controller
@@ -14,6 +15,20 @@ impl StandardController {
             shift_strobe: false,
             state_shift: 0,
         }
+    }
+}
+
+impl Controller for StandardController {
+    fn is_controller_1(&self) -> bool {
+        self.is_controller_1
+    }
+
+    fn get_shift_strobe(&self) -> bool {
+        self.shift_strobe
+    }
+
+    fn set_state_shift(&mut self, val: u8) {
+        self.state_shift = val;
     }
 }
 

--- a/nes/src/controllers/standard_controller.rs
+++ b/nes/src/controllers/standard_controller.rs
@@ -1,0 +1,48 @@
+use memory::Memory;
+
+// https://wiki.nesdev.com/w/index.php/Standard_controller
+pub struct StandardController {
+    is_controller_1: bool,
+    pub shift_strobe: bool,
+    pub state_shift: u8,
+}
+
+impl StandardController {
+    pub fn new(is_controller_1: bool) -> Self {
+        Self {
+            is_controller_1,
+            shift_strobe: false,
+            state_shift: 0,
+        }
+    }
+}
+
+impl Memory for StandardController {
+    fn read(&mut self, addr: u16) -> u8 {
+        if (addr == 0x4016 && self.is_controller_1) || (addr == 0x4017 && !self.is_controller_1) {
+            let out = self.state_shift & 1;
+            if !self.shift_strobe {
+                self.state_shift >>= 1;
+            }
+            out
+        } else {
+            unimplemented!()
+        }
+    }
+
+    fn peek(&self, addr: u16) -> u8 {
+        if (addr == 0x4016 && self.is_controller_1) || (addr == 0x4017 && !self.is_controller_1) {
+            self.state_shift & 1
+        } else {
+            unimplemented!()
+        }
+    }
+
+    fn write(&mut self, addr: u16, data: u8) {
+        if addr == 0x4016 && self.is_controller_1 {
+            self.shift_strobe = (data & 1) == 1;
+        } else {
+            unimplemented!()
+        }
+    }
+}

--- a/nes/src/cpu_mapped_registers.rs
+++ b/nes/src/cpu_mapped_registers.rs
@@ -1,0 +1,71 @@
+use memory::Memory;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+// https://wiki.nesdev.com/w/index.php/2A03
+pub struct CPUMappedRegisters {
+    ppu: Rc<RefCell<dyn Memory>>,
+    apu: Rc<RefCell<dyn Memory>>,
+    joy1: Rc<RefCell<dyn Memory>>,
+    joy2: Rc<RefCell<dyn Memory>>,
+}
+
+impl CPUMappedRegisters {
+    pub fn new(
+        ppu: Rc<RefCell<dyn Memory>>,
+        apu: Rc<RefCell<dyn Memory>>,
+        joy1: Rc<RefCell<dyn Memory>>,
+        joy2: Rc<RefCell<dyn Memory>>,
+    ) -> Self {
+        Self {
+            ppu,
+            apu,
+            joy1,
+            joy2,
+        }
+    }
+
+    fn access(&self, addr: u16, write: bool) -> Result<&Rc<RefCell<dyn Memory>>, &'static str> {
+        if (0x4000 <= addr && addr <= 0x4008)
+            || (0x400A <= addr && addr <= 0x400C)
+            || (0x400E <= addr && addr <= 0x4013)
+            || (addr == 0x4015)
+            || (write && addr == 0x4017)
+        {
+            // Ok(&self.apu)
+            Err("TODO")
+        } else if addr == 0x4014 {
+            Ok(&self.ppu)
+        } else if addr == 0x4016 {
+            Ok(&self.joy1)
+        } else if !write && addr == 0x4017 {
+            Ok(&self.joy2)
+        } else {
+            Err("invalid memory access")
+        }
+    }
+}
+
+impl Memory for CPUMappedRegisters {
+    fn read(&mut self, addr: u16) -> u8 {
+        if let Ok(result) = self.access(addr, false) {
+            result.borrow_mut().read(addr)
+        } else {
+            0
+        }
+    }
+
+    fn peek(&self, addr: u16) -> u8 {
+        if let Ok(result) = self.access(addr, false) {
+            result.borrow_mut().peek(addr)
+        } else {
+            0
+        }
+    }
+
+    fn write(&mut self, addr: u16, data: u8) {
+        if let Ok(result) = self.access(addr, true) {
+            result.borrow_mut().write(addr, data)
+        }
+    }
+}

--- a/nes/src/lib.rs
+++ b/nes/src/lib.rs
@@ -105,6 +105,10 @@ impl NES {
         }
     }
 
+    pub fn get_shift_strobe(&self) -> bool {
+        self.joy1.borrow().shift_strobe
+    }
+
     pub fn try_fill_controller_shift(&mut self, val: u8) {
         let mut joy1 = self.joy1.borrow_mut();
         if joy1.shift_strobe {

--- a/nes/src/nametable_memory.rs
+++ b/nes/src/nametable_memory.rs
@@ -6,49 +6,49 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 pub struct NametableMemory {
-  cart: Rc<RefCell<Cartridge>>,
-  memory: RAM,
+    cart: Rc<RefCell<Cartridge>>,
+    memory: RAM,
 }
 
 impl NametableMemory {
-  pub fn new(cart: Rc<RefCell<Cartridge>>) -> Self {
-    Self {
-      cart,
-      memory: RAM::new(0x400 * 4, 0x0000),
+    pub fn new(cart: Rc<RefCell<Cartridge>>) -> Self {
+        Self {
+            cart,
+            memory: RAM::new(0x400 * 4, 0x0000),
+        }
     }
-  }
 
-  fn mirror(&self, addr: u16) -> u16 {
-    // Adapted from a clever approach by daniel5151
-    let mut _addr = addr;
-    if _addr > 0x3000 {
-      _addr -= 0x1000;
+    fn mirror(&self, addr: u16) -> u16 {
+        // Adapted from a clever approach by daniel5151
+        let mut _addr = addr;
+        if _addr > 0x3000 {
+            _addr -= 0x1000;
+        }
+        let mut fix_4s = 0;
+        let nt_mirroring = match self.cart.borrow().get_nametable_mirroring() {
+            Mirroring::Vertical => [0, 1, 0, 1],
+            Mirroring::Horizontal => [0, 0, 1, 1],
+            Mirroring::FourScreen => {
+                fix_4s = 0x2000;
+                [0, 1, 2, 3]
+            }
+            Mirroring::SingleScreen => [0, 0, 0, 0],
+        };
+
+        nt_mirroring[((_addr - 0x2000) / 0x400) as usize] * 0x400 + (_addr % 0x400) + fix_4s
     }
-    let mut fix_4s = 0;
-    let nt_mirroring = match self.cart.borrow().get_nametable_mirroring() {
-      Mirroring::Vertical => [0, 1, 0, 1],
-      Mirroring::Horizontal => [0, 0, 1, 1],
-      Mirroring::FourScreen => {
-        fix_4s = 0x2000;
-        [0, 1, 2, 3]
-      }
-      Mirroring::SingleScreen => [0, 0, 0, 0],
-    };
-
-    nt_mirroring[((_addr - 0x2000) / 0x400) as usize] * 0x400 + (_addr % 0x400) + fix_4s
-  }
 }
 
 impl Memory for NametableMemory {
-  fn read(&mut self, addr: u16) -> u8 {
-    self.memory.read(self.mirror(addr))
-  }
+    fn read(&mut self, addr: u16) -> u8 {
+        self.memory.read(self.mirror(addr))
+    }
 
-  fn peek(&self, addr: u16) -> u8 {
-    self.memory.peek(self.mirror(addr))
-  }
+    fn peek(&self, addr: u16) -> u8 {
+        self.memory.peek(self.mirror(addr))
+    }
 
-  fn write(&mut self, addr: u16, data: u8) {
-    self.memory.write(self.mirror(addr), data);
-  }
+    fn write(&mut self, addr: u16, data: u8) {
+        self.memory.write(self.mirror(addr), data);
+    }
 }

--- a/ppu/src/background_data.rs
+++ b/ppu/src/background_data.rs
@@ -1,35 +1,35 @@
 pub struct BackgroundData {
-  pub latch: BackgroundLatches,
-  pub shift: BackgroundShifts,
+    pub latch: BackgroundLatches,
+    pub shift: BackgroundShifts,
 }
 
 impl BackgroundData {
-  pub fn new() -> Self {
-    Self {
-      latch: BackgroundLatches {
-        nt_byte: 0,
-        attr_byte: 0,
-        patt_lo: 0,
-        patt_hi: 0,
-      },
-      shift: BackgroundShifts {
-        attr_shift: [0; 2],
-        attr_latch: [false; 2],
-        patt_shift: [0; 2],
-      },
+    pub fn new() -> Self {
+        Self {
+            latch: BackgroundLatches {
+                nt_byte: 0,
+                attr_byte: 0,
+                patt_lo: 0,
+                patt_hi: 0,
+            },
+            shift: BackgroundShifts {
+                attr_shift: [0; 2],
+                attr_latch: [false; 2],
+                patt_shift: [0; 2],
+            },
+        }
     }
-  }
 }
 
 pub struct BackgroundLatches {
-  pub nt_byte: u8,
-  pub attr_byte: u8,
-  pub patt_lo: u8,
-  pub patt_hi: u8,
+    pub nt_byte: u8,
+    pub attr_byte: u8,
+    pub patt_lo: u8,
+    pub patt_hi: u8,
 }
 
 pub struct BackgroundShifts {
-  pub attr_shift: [u8; 2],
-  pub attr_latch: [bool; 2],
-  pub patt_shift: [u16; 2],
+    pub attr_shift: [u8; 2],
+    pub attr_latch: [bool; 2],
+    pub patt_shift: [u16; 2],
 }

--- a/ppu/src/lib.rs
+++ b/ppu/src/lib.rs
@@ -245,7 +245,6 @@ impl PPU {
                 let patt_addr = self.registers.ppuctrl.get_sprite_patt_base()
                     | ((self.oam2.read(4 * spr_num + 1) as u16) << 4)
                     | y;
-                    // | self.registers.curr_addr.get(vram_addr::FINE_Y);
                 self.spr_data.registers[spr_num as usize].patt_shift[0] =
                     self.memory.read(patt_addr + 0);
             }
@@ -256,7 +255,6 @@ impl PPU {
                 let patt_addr = self.registers.ppuctrl.get_sprite_patt_base()
                     | ((self.oam2.read(4 * spr_num + 1) as u16) << 4)
                     | y;
-                    // | self.registers.curr_addr.get(vram_addr::FINE_Y);
                 self.spr_data.registers[spr_num as usize].patt_shift[1] =
                     self.memory.read(patt_addr + 8);
             }
@@ -275,7 +273,8 @@ impl PPU {
             let y = self.oam.read(4 * oam_spr) as u16;
             if y <= self.scan.line && self.scan.line <= (y + 7) {
                 for j in 0..4 {
-                    self.oam2.write(n_found * 4 + j, self.oam.read(oam_spr * 4 + j));
+                    self.oam2
+                        .write(n_found * 4 + j, self.oam.read(oam_spr * 4 + j));
                 }
                 n_found += 1;
             }
@@ -326,13 +325,15 @@ impl PPU {
 
         for sprite_registers in &self.spr_data.registers {
             if sprite_registers.x_counter as u16 <= (self.scan.cycle - 2)
-                && (self.scan.cycle - 2) <= (sprite_registers.x_counter as u16 + 7) {
+                && (self.scan.cycle - 2) <= (sprite_registers.x_counter as u16 + 7)
+            {
                 let flip_h = ((sprite_registers.attr_latch >> 6) & 1) == 0;
                 let mut w = (self.scan.cycle - 2) - (sprite_registers.x_counter as u16);
                 if flip_h {
                     w = 7 - w;
                 }
-                let patt_pair = (((sprite_registers.patt_shift[1] >> w) & 1) << 1) | (((sprite_registers.patt_shift[0] >> w) & 1));
+                let patt_pair = (((sprite_registers.patt_shift[1] >> w) & 1) << 1)
+                    | ((sprite_registers.patt_shift[0] >> w) & 1);
                 if patt_pair != 0 {
                     let color_index = 0x3F10 // Palette RAM base = universal background color
                         | ((sprite_registers.attr_latch as u16) << 2) // "Palette number from attribute table"

--- a/sdl-ui/Cargo.toml
+++ b/sdl-ui/Cargo.toml
@@ -11,5 +11,5 @@ memory = { path = "../memory" }
 sdl2 = "0.34.3"
 rand = "0.8.3"
 
-[profile.release]
-debug = true
+# [profile.release]
+# debug = true

--- a/sdl-ui/Cargo.toml
+++ b/sdl-ui/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 nes = { path = "../nes" }
 cpu = { path = "../cpu" }
 memory = { path = "../memory" }
-sdl2 = "0.34"
+sdl2 = "0.34.3"
 rand = "0.8.3"
 
-# [profile.release]
-# debug = true
+[profile.release]
+debug = true

--- a/sdl-ui/src/main.rs
+++ b/sdl-ui/src/main.rs
@@ -7,6 +7,7 @@ use std::process;
 
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
+use sdl2::keyboard::Scancode;
 use sdl2::pixels::PixelFormatEnum;
 
 const COLORS: &'static [i32] = &[
@@ -57,6 +58,17 @@ fn main() {
 
     let mut screen_buff = [0u8; 256 * 240 * 3];
 
+    let controls = vec![
+        Scancode::Right,
+        Scancode::Left,
+        Scancode::Down,
+        Scancode::Up,
+        Scancode::Return,
+        Scancode::RShift,
+        Scancode::Z,
+        Scancode::X,
+    ];
+
     use std::time::Instant;
     let mut now = Instant::now();
     let mut frame_count = 0;
@@ -64,9 +76,17 @@ fn main() {
     let checks_per_rate_report = 2;
     let get_fps = |micros| (1f32 / ((micros / frames_per_rate_check) as f32 * 0.000001)) as u32;
     loop {
+        let mut controller_byte = 0;
+        for scancode in &controls {
+            let bit = event_pump.keyboard_state().is_scancode_pressed(*scancode) as u8;
+            controller_byte <<= 1;
+            controller_byte |= bit;
+        }
+        nes.try_fill_controller_shift(controller_byte);
         nes.tick();
 
-        if frame_count % 10 == 0 { // Temporary fix for slow event poll
+        if frame_count % 7 == 0 {
+            // Temporary fix for slow event poll
             for event in event_pump.poll_iter() {
                 match event {
                     Event::Quit { .. }


### PR DESCRIPTION
The keyboard now maps to a standard NES controller plugged into the first port. SDL2 will now fill an input shift register whenever the NES CPU requests input, i.e. by writing 1 to the low bit of register $4016. The controller implementation is very generic, allowing for future extensions such as a second controller, extension devices like the Light Gun, and alternate interfaces such as gamepads.