### PR TITLE
Realistic PPU 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
     "ppu",
     "memory",
 ]
+
+# [profile.release]
+# debug = true

--- a/cpu/src/instruction.rs
+++ b/cpu/src/instruction.rs
@@ -114,8 +114,8 @@ lazy_static! {
         add("*ARR", vec![(0x6B, IMM, 2)]);
         add("*SAX", vec![(0x83, INX, 6), (0x87, ZER, 3), (0x8F, ABS, 4), (0x97, ZEY, 4)]);
         add("*SBC", vec![(0xEB, IMM, 2)]);
-        add("*LAX", vec![(0xA3, INX, 6), (0xA7, ZER, 3), (0xAF, ABS, 4), (0xB3, INY, 5),
-                        (0xB7, ZEY, 4), (0xBF, ABY, 4)]);
+        add("*LAX", vec![(0xA3, INX, 6), (0xA7, ZER, 3), (0xAB, IMM, 4), (0xAF, ABS, 4),
+                        (0xB3, INY, 5), (0xB7, ZEY, 4), (0xBF, ABY, 4)]);
         add("*LAS", vec![(0xBB, ABY, 4)]);
         add("*DCP", vec![(0xC3, INX, 8), (0xC7, ZER, 5), (0xCF, ABS, 6), (0xD3, INY, 8),
                         (0xD7, ZEX, 6), (0xDB, ABY, 7), (0xDF, ABX, 7)]);
@@ -123,6 +123,7 @@ lazy_static! {
                         (0xF7, ZEX, 6), (0xFB, ABY, 7), (0xFF, ABX, 7)]);
         add("*ANC", vec![(0x0B, IMM, 2), (0x2B, IMM, 2)]);
         add("*SHX", vec![(0x9E, ABY, 5)]);
+        add("*SHY", vec![(0x9C, ABX, 5)]);
         add("*AXA", vec![(0x93, INY, 6), (0x9F, ABX, 5)]);
         add("*AXS", vec![(0xCB, IMM, 2)]);
         map

--- a/nes/src/lib.rs
+++ b/nes/src/lib.rs
@@ -41,7 +41,6 @@ impl NES {
             0x3EFF,
             Rc::new(RefCell::new(NametableMemory::new(cart.clone()))),
         );
-        // ppu_mmu.map_ram_mirrored(0x3F00, 0x3FFF, 0x0020); // Palette RAM indices
         ppu_mmu.map(0x3F00, 0x3FFF, Rc::new(RefCell::new(PaletteRAM::new()))); // Palette RAM indices
         let ppu = Rc::new(RefCell::new(PPU::new(Box::from(ppu_mmu))));
 

--- a/nes/src/lib.rs
+++ b/nes/src/lib.rs
@@ -2,6 +2,7 @@ mod cartridge;
 mod controllers;
 mod cpu_mapped_registers;
 mod nametable_memory;
+mod palette_ram;
 
 use crate::cartridge::Cartridge;
 use crate::controllers::Controller;
@@ -9,6 +10,7 @@ use crate::controllers::NoController;
 use crate::controllers::StandardController;
 use crate::cpu_mapped_registers::CPUMappedRegisters;
 use crate::nametable_memory::NametableMemory;
+use crate::palette_ram::PaletteRAM;
 
 use cpu::CPU;
 use memory::mmu::MMU;
@@ -39,7 +41,8 @@ impl NES {
             0x3EFF,
             Rc::new(RefCell::new(NametableMemory::new(cart.clone()))),
         );
-        ppu_mmu.map_ram_mirrored(0x3F00, 0x3FFF, 0x0020); // Palette RAM indices
+        // ppu_mmu.map_ram_mirrored(0x3F00, 0x3FFF, 0x0020); // Palette RAM indices
+        ppu_mmu.map(0x3F00, 0x3FFF, Rc::new(RefCell::new(PaletteRAM::new()))); // Palette RAM indices
         let ppu = Rc::new(RefCell::new(PPU::new(Box::from(ppu_mmu))));
 
         let cpu_mapped_registers = Rc::new(RefCell::new(CPUMappedRegisters::new(

--- a/nes/src/nametable_memory.rs
+++ b/nes/src/nametable_memory.rs
@@ -21,7 +21,7 @@ impl NametableMemory {
     fn mirror(&self, addr: u16) -> u16 {
         // Adapted from a clever approach by daniel5151
         let mut _addr = addr;
-        if _addr > 0x3000 {
+        if _addr >= 0x3000 {
             _addr -= 0x1000;
         }
         let mut fix_4s = 0;

--- a/nes/src/palette_ram.rs
+++ b/nes/src/palette_ram.rs
@@ -1,0 +1,39 @@
+use memory::ram::RAM;
+use memory::Memory;
+
+// https://wiki.nesdev.com/w/index.php/PPU_palettes
+pub struct PaletteRAM {
+    memory: RAM,
+}
+
+impl PaletteRAM {
+    pub fn new() -> Self {
+        Self {
+            memory: RAM::new(0x20, 0x00),
+        }
+    }
+
+    fn mirror(&self, addr: u16) -> u16 {
+        // "Addresses $3F10/$3F14/$3F18/$3F1C are mirrors of $3F00/$3F04/$3F08/$3F0C"
+        let mut mirrored = addr;
+        mirrored %= 0x20;
+        if (mirrored % 4 == 0) && mirrored >= 0x10 {
+            mirrored -= 0x10;
+        }
+        mirrored
+    }
+}
+
+impl Memory for PaletteRAM {
+    fn read(&mut self, addr: u16) -> u8 {
+        self.memory.read(self.mirror(addr))
+    }
+
+    fn peek(&self, addr: u16) -> u8 {
+        self.memory.peek(self.mirror(addr))
+    }
+
+    fn write(&mut self, addr: u16, data: u8) {
+        self.memory.write(self.mirror(addr), data);
+    }
+}

--- a/ppu/src/lib.rs
+++ b/ppu/src/lib.rs
@@ -7,7 +7,6 @@ mod scan;
 mod sprite_data;
 
 use background_data::BackgroundData;
-use memory::ram::RAM;
 use memory::Memory;
 use registers::*;
 use scan::Scan;
@@ -22,8 +21,8 @@ pub struct PPU {
     bg_data: BackgroundData,
     spr_data: SpriteData,
     memory: Box<dyn Memory>,
-    oam: RAM,
-    oam2: RAM,
+    oam: [u8; 0x100],
+    oam2: [u8; 0x20],
     dma_option: Option<Rc<RefCell<dyn Memory>>>,
     dma_request: Option<u8>,
     pub framebuffer: [[u8; 256]; 240],
@@ -39,8 +38,8 @@ impl PPU {
             bg_data: BackgroundData::new(),
             spr_data: SpriteData::new(),
             memory,
-            oam: RAM::new(0x100, 0),
-            oam2: RAM::new(0x20, 0),
+            oam: [0u8; 0x100],
+            oam2: [0u8; 0x20],
             dma_option: None,
             dma_request: None,
             framebuffer: [[0; 256]; 240],
@@ -85,7 +84,7 @@ impl PPU {
             }
 
             if self.scan.on_spr_fetch_cycle() {
-                self.spr_fetch((self.scan.cycle - 257) / 8, (self.scan.cycle - 1) % 8);
+                self.spr_fetch((self.scan.cycle - 256) / 8, (self.scan.cycle - 1) % 8);
             }
         }
 
@@ -93,7 +92,7 @@ impl PPU {
         if self.scan.on_visible_line() {
             if self.scan.on_oam2_clear_cycle() {
                 if (self.scan.cycle - 1) % 2 == 0 {
-                    self.oam2.write((self.scan.cycle - 1) / 2, 0xFF);
+                    self.oam2[((self.scan.cycle - 1) as usize) / 2] = 0xFF;
                 }
             } else if self.scan.on_spr_eval_cycle() {
                 if self.scan.cycle == 65 {
@@ -107,8 +106,23 @@ impl PPU {
                 || (321 <= self.scan.cycle && self.scan.cycle <= 336)
             {
                 let (mut pixel_on, mut color) = self.get_bg_pixel();
-                let (spr_pixel_on, spr_color) = self.get_spr_pixel();
+                let (spr_pixel_on, spr_color, spr_zero) = self.get_spr_pixel();
                 if spr_pixel_on {
+                    if pixel_on
+                        && spr_zero
+                        && self.registers.ppumask.is_rendering()
+                        && (self.scan.cycle != 256)
+                        && !((1 <= self.scan.cycle && self.scan.cycle <= 8)
+                            && (!self.registers.ppumask.contains(MaskRegister::BACK_LEFT_COL)
+                                || !self
+                                    .registers
+                                    .ppumask
+                                    .contains(MaskRegister::SPRITE_LEFT_COL)))
+                    {
+                        self.registers
+                            .ppustatus
+                            .insert(StatusRegister::SPRITE_ZERO_HIT);
+                    }
                     pixel_on = true;
                     color = spr_color;
                 }
@@ -203,16 +217,11 @@ impl PPU {
                     | self.registers.curr_addr.get(vram_addr::FINE_Y); // "the row number within a tile"
 
                 self.bg_data.latch.patt_lo = self.memory.read(patt_addr + 0);
+                self.bg_data.latch.patt_hi = self.memory.read(patt_addr + 8);
             }
             6 => {
                 // Read pattern data from the upper bit plane of the pattern table
-                // TODO: This could be stored so as to avoid computing it twice
-                let patt_addr = self.registers.ppuctrl.get_patt_base()
-                    | ((self.bg_data.latch.nt_byte as u16) << 4)
-                    | self.registers.curr_addr.get(vram_addr::FINE_Y);
-
-                // Same as lower bit, but adding 0b1000 selects the upper table plane
-                self.bg_data.latch.patt_hi = self.memory.read(patt_addr + 8);
+                // (Performed alongside pattern low to avoid repeating work)
             }
             7 => {
                 if self.registers.ppumask.is_rendering() {
@@ -236,38 +245,65 @@ impl PPU {
                 // Garbage nametable byte
             }
             2 => {
+                self.spr_data.registers[spr_num as usize].num = spr_num;
                 self.spr_data.registers[spr_num as usize].attr_latch =
-                    self.oam2.read(4 * spr_num + 2);
+                    self.oam2[4 * (spr_num as usize) + 2];
             }
             3 => {
                 self.spr_data.registers[spr_num as usize].x_counter =
-                    self.oam2.read(4 * spr_num + 3);
+                    self.oam2[4 * (spr_num as usize) + 3];
             }
             4 => {
                 // Pattern table tile low
-                // TODO: This
-                let y = self
+                let mut y = self
                     .scan
                     .line
-                    .wrapping_sub(self.oam2.read(4 * spr_num + 0) as u16);
-                let patt_addr = self.registers.ppuctrl.get_sprite_patt_base()
-                    | ((self.oam2.read(4 * spr_num + 1) as u16) << 4)
-                    | y;
+                    .wrapping_sub(self.oam2[4 * (spr_num as usize) + 0] as u16);
+                let mut any_good = false;
+                for i in 0..4 {
+                    if self.oam2[4 * (spr_num as usize) + i] != 0xFF {
+                        any_good = true;
+                        break;
+                    }
+                }
+                if !any_good {
+                    y = 0;
+                }
+
+                let mut tile_index = self.oam2[4 * (spr_num as usize) + 1] as u16;
+                let base = if self
+                    .registers
+                    .ppuctrl
+                    .contains(ControlRegister::SPRITE_HEIGHT)
+                {
+                    0x1000 * (tile_index & 1)
+                } else {
+                    self.registers.ppuctrl.get_sprite_patt_base()
+                };
+
+                let flip_v = self.oam2[4 * (spr_num as usize) + 2] >> 7 == 1;
+                if flip_v {
+                    y = self.registers.ppuctrl.get_sprite_height() - 1 - y;
+                }
+                if self
+                    .registers
+                    .ppuctrl
+                    .contains(ControlRegister::SPRITE_HEIGHT)
+                {
+                    tile_index &= 0b1111_1110;
+                    if y > 7 {
+                        tile_index += 1;
+                        y -= 8;
+                    }
+                }
+                let patt_addr = base | (tile_index << 4) | y;
                 self.spr_data.registers[spr_num as usize].patt_shift[0] =
                     self.memory.read(patt_addr + 0);
-            }
-            6 => {
-                // Pattern table tile high
-                // TODO: This
-                let y = self
-                    .scan
-                    .line
-                    .wrapping_sub(self.oam2.read(4 * spr_num + 0) as u16);
-                let patt_addr = self.registers.ppuctrl.get_sprite_patt_base()
-                    | ((self.oam2.read(4 * spr_num + 1) as u16) << 4)
-                    | y;
                 self.spr_data.registers[spr_num as usize].patt_shift[1] =
                     self.memory.read(patt_addr.wrapping_add(8));
+            }
+            6 => {
+                // Pattern table tile high (fetched alongside low to avoid repeating work)
             }
             _ => {} // Reads take two cycles, so we just skip the odd ones
         }
@@ -281,11 +317,12 @@ impl PPU {
             if n_found == 8 {
                 break;
             }
-            let y = self.oam.read(4 * oam_spr) as u16;
-            if y <= self.scan.line && self.scan.line <= (y + 7) {
+            let y = self.oam[4 * oam_spr as usize] as u16;
+            if y <= self.scan.line
+                && self.scan.line < y.wrapping_add(self.registers.ppuctrl.get_sprite_height())
+            {
                 for j in 0..4 {
-                    self.oam2
-                        .write(n_found * 4 + j, self.oam.read(oam_spr * 4 + j));
+                    self.oam2[n_found * 4 + j] = self.oam[oam_spr as usize * 4 + j];
                 }
                 n_found += 1;
             }
@@ -327,19 +364,18 @@ impl PPU {
         (patt_pair != 0, self.memory.read(color_index))
     }
 
-    fn get_spr_pixel(&mut self) -> (bool, u8) {
+    fn get_spr_pixel(&mut self) -> (bool, u8, bool) {
         // https://wiki.nesdev.com/w/index.php/PPU_rendering#Preface
-        // TODO: Implement the actual pattern behavior
         if self.scan.cycle == 1 {
-            return (false, 0x00);
+            return (false, 0x00, false);
         }
 
         for sprite_registers in &self.spr_data.registers {
-            if sprite_registers.x_counter as u16 <= (self.scan.cycle - 2)
-                && (self.scan.cycle - 2) <= (sprite_registers.x_counter as u16 + 7)
+            if sprite_registers.x_counter as u16 <= (self.scan.cycle - 1)
+                && (self.scan.cycle - 1) <= (sprite_registers.x_counter as u16 + 7)
             {
                 let flip_h = ((sprite_registers.attr_latch >> 6) & 1) == 0;
-                let mut w = (self.scan.cycle - 2) - (sprite_registers.x_counter as u16);
+                let mut w = (self.scan.cycle - 1) - (sprite_registers.x_counter as u16);
                 if flip_h {
                     w = 7 - w;
                 }
@@ -349,12 +385,16 @@ impl PPU {
                     let color_index = 0x3F10 // Palette RAM base = universal background color
                         | ((sprite_registers.attr_latch as u16) << 2) // "Palette number from attribute table"
                         | (patt_pair as u16); // "Pixel value from tile data"
-                    return (true, self.memory.read(color_index));
+                    return (
+                        true,
+                        self.memory.read(color_index),
+                        sprite_registers.num == 0,
+                    );
                 }
             }
         }
 
-        (false, 0x00)
+        (false, 0x00, false)
     }
 
     fn run_oam_dma(&mut self, data: u8) {
@@ -383,7 +423,7 @@ impl PPU {
             self.cpu_cycle(); // Read takes 1 CPU cycle
 
             // TODO: I think this should be oamaddr, but it has to be reset at some point
-            self.oam.write(i, dma_val);
+            self.oam[i as usize] = dma_val;
             // self.oam.write(self.registers.oamaddr as u16, dma_val);
             // self.registers.oamaddr = self.registers.oamaddr.wrapping_add(1);
             self.cpu_cycle(); // Write takes another
@@ -421,7 +461,7 @@ impl Memory for PPU {
                 if self.scan.on_visible_line() && self.scan.on_oam2_clear_cycle() {
                     0xFF
                 } else {
-                    self.oam.read(self.registers.oamaddr as u16)
+                    self.oam[self.registers.oamaddr as usize]
                 }
             }
             register_addrs::PPUDATA => {
@@ -460,7 +500,7 @@ impl Memory for PPU {
                 if self.scan.on_visible_line() && self.scan.on_oam2_clear_cycle() {
                     0xFF
                 } else {
-                    self.oam.peek(self.registers.oamaddr as u16)
+                    self.oam[self.registers.oamaddr as usize]
                 }
             }
             register_addrs::PPUDATA => {
@@ -498,7 +538,7 @@ impl Memory for PPU {
             register_addrs::PPUMASK => self.registers.ppumask.write(data),
             register_addrs::OAMADDR => self.registers.oamaddr = data,
             register_addrs::OAMDATA => {
-                self.oam.write(self.registers.oamaddr as u16, data);
+                self.oam[self.registers.oamaddr as usize] = data;
                 self.registers.oamaddr += self.registers.oamaddr.wrapping_add(1);
             }
             register_addrs::PPUSCROLL => {

--- a/ppu/src/registers.rs
+++ b/ppu/src/registers.rs
@@ -3,8 +3,8 @@ pub mod register_addrs {
     pub const PPUCTRL: u16 = 0x2000;
     pub const PPUMASK: u16 = 0x2001;
     pub const PPUSTATUS: u16 = 0x2002;
-    pub const OAMDATA: u16 = 0x2003;
-    pub const OAMADDR: u16 = 0x2004;
+    pub const OAMADDR: u16 = 0x2003;
+    pub const OAMDATA: u16 = 0x2004;
     pub const PPUSCROLL: u16 = 0x2005;
     pub const PPUADDR: u16 = 0x2006;
     pub const PPUDATA: u16 = 0x2007;

--- a/ppu/src/registers.rs
+++ b/ppu/src/registers.rs
@@ -163,7 +163,7 @@ impl AddressRegister {
     }
 
     fn bitmask(mask: (u16, u16)) -> u16 {
-        ((1 << mask.1) - 1) << mask.0 // e.g. (5, 5) => 1111100000
+        ((1 << mask.1) - 1) << mask.0 // e.g. (4, 5) => 111110000
     }
 
     pub fn set(&mut self, mask: (u16, u16), val: u8) {

--- a/ppu/src/sprite_data.rs
+++ b/ppu/src/sprite_data.rs
@@ -27,6 +27,7 @@ impl SpriteData {
 
 #[derive(Clone, Copy)]
 pub struct SpriteRegisters {
+    pub num: u16,
     pub patt_shift: [u8; 2],
     pub attr_latch: u8,
     pub x_counter: u8,
@@ -35,6 +36,7 @@ pub struct SpriteRegisters {
 impl SpriteRegisters {
     pub fn new() -> Self {
         Self {
+            num: 0,
             patt_shift: [0; 2],
             attr_latch: 0,
             x_counter: 0,

--- a/ppu/src/sprite_data.rs
+++ b/ppu/src/sprite_data.rs
@@ -1,10 +1,10 @@
 // https://wiki.nesdev.com/w/index.php/PPU_sprite_evaluation
 pub struct SpriteData {
     pub registers: [SpriteRegisters; 8],
-    pub spr_num: u8,  // "sprite n (0-63)"
-    pub byte_num: u8, // "byte m (0-3)"
-    pub oam_byte: u8, // Filled on odd cycles
-    // TODO: Can I just use spr_num % 8? I think not?
+    pub eval_state: SpriteEvalState,
+    pub spr_num: u8,    // "sprite n (0-63)"
+    pub byte_num: u8,   // "byte m (0-3)"
+    pub oam_byte: u8,   // Filled on odd cycles
     pub oam2_index: u8, // Number of sprites found on this line.
 }
 
@@ -12,6 +12,7 @@ impl SpriteData {
     pub fn new() -> Self {
         Self {
             registers: [SpriteRegisters::new(); 8],
+            eval_state: SpriteEvalState::CopyY,
             spr_num: 0,
             byte_num: 0,
             oam_byte: 0,
@@ -20,8 +21,11 @@ impl SpriteData {
     }
 
     pub fn reset(&mut self) {
+        self.eval_state = SpriteEvalState::CopyY;
+        self.spr_num = 0;
         self.byte_num = 0;
         self.oam_byte = 0;
+        self.oam2_index = 0;
     }
 }
 
@@ -42,4 +46,14 @@ impl SpriteRegisters {
             x_counter: 0,
         }
     }
+}
+
+// https://wiki.nesdev.com/w/index.php/PPU_sprite_evaluation#Details Cycles 65-256: Sprite evaluation
+pub enum SpriteEvalState {
+    CopyY,                // Step 1
+    CopyRemaining(usize), // Step 1a (with index m to be copied)
+    IncrementN,           // Step 2
+    EvaluateAsY,          // Step 3
+    Overflow(usize),      // Step 3a (with number of bytes read so far (0-2))
+    Done,                 // Step 4
 }

--- a/sdl-ui/Cargo.toml
+++ b/sdl-ui/Cargo.toml
@@ -10,6 +10,3 @@ cpu = { path = "../cpu" }
 memory = { path = "../memory" }
 sdl2 = "0.34.3"
 rand = "0.8.3"
-
-# [profile.release]
-# debug = true


### PR DESCRIPTION
- Fixes several small CPU bugs that made flags and timing inaccurate
- Fixes a large CPU bug where cycles where instructions actually run were not counted
    - This fixes a lot of PPU problems, because NMI is now nearly accurately synced
- Implements a nearly cycle-accurate PPU sprite evaluation procedure
    - The PPU now has a sprite data subsystem that holds the state and data of a state machine
    - Cycle by cycle, the PPU now emulates sprite evaluation reads, writes, and dummy fetches in a nearly accurate way
- Fix a number of small PPU bugs
- Added an FPS cap of ~60FPS (in reality, it can be improved, and currently locks at 58-59 on my machine)