### PR TITLE
Several new mappers

### DIFF
--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -116,6 +116,19 @@ impl CPU {
         self.pc = self.memory.read_u16(NMI_VEC);
     }
 
+    pub fn irq(&mut self) {
+        if self.p.contains(StatusRegister::IRQ_DISABLE) {
+            return;
+        }
+
+        self.stack_push_u16(self.pc);
+        let mut status = self.p.clone();
+        status.insert(StatusRegister::BREAK_HI);
+        status.remove(StatusRegister::BREAK_LO);
+        self.stack_push(status.bits());
+        self.pc = self.memory.read_u16(IRQ_VEC);
+    }
+
     fn format_step(&self, op: &Instruction) -> String {
         format!("{:<48}{}", self.format_instr(op), self.format_state())
     }

--- a/nes/src/cartridge/cartridge_metadata.rs
+++ b/nes/src/cartridge/cartridge_metadata.rs
@@ -95,7 +95,7 @@ impl CartridgeMetadata {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Mirroring {
     Horizontal,
     Vertical,

--- a/nes/src/cartridge/mapper/mapper0.rs
+++ b/nes/src/cartridge/mapper/mapper0.rs
@@ -1,13 +1,12 @@
 use crate::cartridge::Mapper;
-use memory::rom::ROM;
 use memory::Memory;
 
 // https://wiki.nesdev.com/w/index.php/NROM
 pub struct Mapper0 {
     n_prg_banks: u16,
-    n_chr_banks: u16,
-    prg_rom: ROM,
-    chr_rom: ROM,
+    prg_rom: Vec<u8>,
+    chr_mem: Vec<u8>,
+    chr_mem_is_ram: bool,
 }
 
 impl Mapper for Mapper0 {}
@@ -16,15 +15,14 @@ impl Mapper0 {
     pub fn new(n_prg_banks: u16, n_chr_banks: u16, prg_data: Vec<u8>, chr_data: Vec<u8>) -> Self {
         Self {
             n_prg_banks,
-            n_chr_banks,
-            prg_rom: ROM {
-                memory: prg_data,
-                start: 0x8000,
+            chr_mem: if n_chr_banks == 0 {
+                // TODO: RAM sizes
+                vec![0; 0x2000]
+            } else {
+                chr_data
             },
-            chr_rom: ROM {
-                memory: chr_data,
-                start: 0x0000,
-            },
+            chr_mem_is_ram: n_chr_banks == 0,
+            prg_rom: prg_data,
         }
     }
 }
@@ -36,21 +34,20 @@ impl Memory for Mapper0 {
 
     fn peek(&self, addr: u16) -> u8 {
         if addr <= 0x1FFF {
-            self.chr_rom.peek(addr % (self.n_chr_banks * 0x2000))
+            self.chr_mem[addr as usize % self.chr_mem.len()]
         } else {
-            self.prg_rom
-                .peek(((addr - 0x8000) % (self.n_prg_banks * 0x4000)) + 0x8000)
+            self.prg_rom[((addr as usize - 0x8000) % (self.n_prg_banks as usize * 0x4000))]
         }
     }
 
     fn write(&mut self, addr: u16, data: u8) {
         if addr <= 0x1FFF {
-            self.chr_rom.write(addr % (self.n_chr_banks * 0x2000), data)
+            if self.chr_mem_is_ram {
+                let len = self.chr_mem.len();
+                self.chr_mem[addr as usize % len] = data;
+            }
         } else {
-            self.prg_rom.write(
-                ((addr - 0x8000) % (self.n_prg_banks * 0x4000)) + 0x8000,
-                data,
-            )
+            self.prg_rom[((addr as usize - 0x8000) % (self.n_prg_banks as usize * 0x4000))] = data;
         }
     }
 }

--- a/nes/src/cartridge/mapper/mapper1.rs
+++ b/nes/src/cartridge/mapper/mapper1.rs
@@ -5,7 +5,6 @@ use memory::Memory;
 // https://wiki.nesdev.com/w/index.php/MMC1
 pub struct Mapper1 {
     n_prg_banks: u16,
-    n_chr_banks: u16,
     prg_rom: Vec<u8>,
     prg_ram: Vec<u8>,
     chr_mem: Vec<u8>,
@@ -24,7 +23,6 @@ impl Mapper1 {
     pub fn new(n_prg_banks: u16, n_chr_banks: u16, prg_data: Vec<u8>, chr_data: Vec<u8>) -> Self {
         Self {
             n_prg_banks,
-            n_chr_banks,
             prg_rom: prg_data,
             prg_ram: vec![0; 0x2000],
             chr_mem: if n_chr_banks == 0 {
@@ -62,7 +60,6 @@ impl Mapper for Mapper1 {
         }
     }
 
-    // TODO: Reset method
     fn reset(&mut self) {
         self.last_write_timer = 0;
         self.shift_register = 0b10000;
@@ -72,10 +69,10 @@ impl Mapper for Mapper1 {
         self.chr_bank_1 = 0;
         self.prg_bank = 0;
 
-        // TODO: Should PRG ram be cleared?
         // TODO: Different RAM sizes
         if self.chr_mem_is_ram {
             self.chr_mem = vec![0; 0x2000];
+            self.prg_ram = vec![0; 0x2000];
         }
     }
 }

--- a/nes/src/cartridge/mapper/mapper2.rs
+++ b/nes/src/cartridge/mapper/mapper2.rs
@@ -1,0 +1,50 @@
+use crate::cartridge::Mapper;
+use memory::Memory;
+
+// https://wiki.nesdev.com/w/index.php/UxROM
+pub struct Mapper2 {
+    n_prg_banks: u16,
+    prg_rom: Vec<u8>,
+    chr_mem: Vec<u8>,
+    prg_bank: u8,
+}
+
+impl Mapper for Mapper2 {}
+
+impl Mapper2 {
+    pub fn new(n_prg_banks: u16, prg_data: Vec<u8>) -> Self {
+        Self {
+            n_prg_banks,
+            chr_mem: vec![0; 0x2000],
+            prg_rom: prg_data,
+            prg_bank: 0,
+        }
+    }
+}
+
+impl Memory for Mapper2 {
+    fn read(&mut self, addr: u16) -> u8 {
+        self.peek(addr)
+    }
+
+    fn peek(&self, addr: u16) -> u8 {
+        if addr <= 0x1FFF {
+            self.chr_mem[addr as usize % self.chr_mem.len()]
+        } else if 0x8000 <= addr && addr <= 0xBFFF {
+            self.prg_rom[self.prg_bank as usize * 0x4000 + (addr as usize - 0x8000)]
+        } else if 0xC000 <= addr {
+            self.prg_rom[(self.n_prg_banks as usize - 1) * 0x4000 + (addr as usize - 0xC000)]
+        } else {
+            0x0
+        }
+    }
+
+    fn write(&mut self, addr: u16, data: u8) {
+        if addr <= 0x1FFF {
+            let len = self.chr_mem.len();
+            self.chr_mem[addr as usize % len] = data;
+        } else if addr >= 0x8000 {
+            self.prg_bank = data;
+        }
+    }
+}

--- a/nes/src/cartridge/mapper/mapper3.rs
+++ b/nes/src/cartridge/mapper/mapper3.rs
@@ -1,0 +1,45 @@
+use crate::cartridge::Mapper;
+use memory::Memory;
+
+// https://wiki.nesdev.com/w/index.php/INES_Mapper_003
+pub struct Mapper3 {
+    n_chr_banks: u16,
+    prg_rom: Vec<u8>,
+    chr_rom: Vec<u8>,
+    chr_bank: u8,
+}
+
+impl Mapper for Mapper3 {}
+
+impl Mapper3 {
+    pub fn new(n_chr_banks: u16, prg_data: Vec<u8>, chr_data: Vec<u8>) -> Self {
+        Self {
+            n_chr_banks: n_chr_banks,
+            prg_rom: prg_data,
+            chr_rom: chr_data,
+            chr_bank: 0,
+        }
+    }
+}
+
+impl Memory for Mapper3 {
+    fn read(&mut self, addr: u16) -> u8 {
+        self.peek(addr)
+    }
+
+    fn peek(&self, addr: u16) -> u8 {
+        if addr <= 0x1FFF {
+            self.chr_rom[(self.chr_bank as usize * 0x2000) + addr as usize]
+        } else if 0x8000 <= addr {
+            self.prg_rom[addr as usize - 0x8000]
+        } else {
+            0x0
+        }
+    }
+
+    fn write(&mut self, addr: u16, data: u8) {
+        if addr >= 0x8000 {
+            self.chr_bank = data % (self.n_chr_banks as u8);
+        }
+    }
+}

--- a/nes/src/cartridge/mapper/mapper4.rs
+++ b/nes/src/cartridge/mapper/mapper4.rs
@@ -1,0 +1,250 @@
+use crate::cartridge::Mapper;
+use crate::cartridge::Mirroring;
+use memory::Memory;
+
+// https://wiki.nesdev.com/w/index.php/MMC3
+pub struct Mapper4 {
+    n_prg_banks: u16,
+    n_chr_banks: u16,
+    prg_rom: Vec<u8>,
+    prg_ram: Vec<u8>,
+    chr_mem: Vec<u8>,
+    chr_mem_is_ram: bool,
+
+    // Memory mapping ($8000-$9FFF, $A000-$BFFF)
+    select_bank_register: u8,
+    bank_registers: [u8; 8],
+    prg_bank_mode: bool,
+    chr_bank_mode: bool,
+    mirroring: Mirroring,
+    write_protection: bool,
+    prg_ram_enable: bool,
+
+    // Scanline counting ($C000-$DFFF, and $E000-$FFFF)
+    irq_counter: u8,
+    irq_latch: u8,
+    schedule_irq_reload: bool,
+    irq_enable: bool,
+    previous_a12: u16,
+    trigger_irq: bool,
+
+    // A submapper with PRG ram and write protection
+    is_mmc6: bool,
+    mmc6_ram_enable: bool,
+    mmc6_ram_lo_write: bool,
+    mmc6_ram_lo_read: bool,
+    mmc6_ram_hi_write: bool,
+    mmc6_ram_hi_read: bool,
+}
+
+impl Mapper for Mapper4 {
+    fn get_nametable_mirroring(&self) -> Option<Mirroring> {
+        Some(self.mirroring)
+    }
+
+    fn check_irq(&mut self) -> bool {
+        let ret = self.trigger_irq;
+        self.trigger_irq = false;
+        ret
+    }
+}
+
+impl Mapper4 {
+    pub fn new(
+        n_prg_banks: u16,
+        n_chr_banks: u16,
+        prg_data: Vec<u8>,
+        chr_data: Vec<u8>,
+        is_mmc6: bool,
+    ) -> Self {
+        Self {
+            n_prg_banks,
+            n_chr_banks: std::cmp::max(n_prg_banks, 1),
+            prg_rom: prg_data,
+            prg_ram: vec![0; 0x2000],
+            chr_mem: if n_chr_banks == 0 {
+                // TODO: RAM sizes
+                vec![0; 0x2000]
+            } else {
+                chr_data
+            },
+            chr_mem_is_ram: n_chr_banks == 0,
+
+            select_bank_register: 0,
+            bank_registers: [0; 8],
+            prg_bank_mode: false,
+            chr_bank_mode: false,
+            mirroring: Mirroring::Vertical,
+            write_protection: false,
+            prg_ram_enable: false,
+
+            irq_counter: 0,
+            irq_latch: 0,
+            schedule_irq_reload: false,
+            irq_enable: false,
+            previous_a12: 0,
+            trigger_irq: false,
+
+            is_mmc6,
+            mmc6_ram_enable: false,
+            mmc6_ram_lo_write: false,
+            mmc6_ram_lo_read: false,
+            mmc6_ram_hi_write: false,
+            mmc6_ram_hi_read: false,
+        }
+    }
+
+    fn map_chr(&self, addr: u16) -> usize {
+        if (self.chr_bank_mode && addr >= 0x1000) || (!self.chr_bank_mode && addr < 0x1000) {
+            let bank = self.bank_registers[((addr % 0x1000) >= 0x800) as usize];
+            let high = if (addr % 0x800) >= 0x400 { 0x400 } else { 0 };
+            0x800 * ((bank as usize >> 1) % (self.n_chr_banks as usize * 4)) + high
+        } else {
+            let bank = self.bank_registers[((addr as usize % 0x1000) / 0x400) + 2];
+            0x400 * (bank as usize % (self.n_chr_banks as usize * 8))
+        }
+    }
+
+    fn map_prg(&self, addr: u16) -> usize {
+        let r6 = (self.bank_registers[6] & 0b111111) as u16;
+        let r7 = (self.bank_registers[7] & 0b111111) as u16;
+        let last = self.n_prg_banks * 2 - 1;
+        let second_last = self.n_prg_banks * 2 - 2;
+        let banks = if self.prg_bank_mode {
+            [second_last, r7, r6, last]
+        } else {
+            [r6, r7, second_last, last]
+        };
+
+        0x2000 * banks[(addr as usize - 0x8000) / 0x2000] as usize
+    }
+}
+
+impl Memory for Mapper4 {
+    fn read(&mut self, addr: u16) -> u8 {
+        // IRQ counter is a side-effect of reading
+        if addr <= 0x1FFF {
+            let a12 = (addr >> 12) & 1;
+            if (self.previous_a12 == 0) && (a12 == 1) {
+                if self.schedule_irq_reload {
+                    self.irq_counter = self.irq_latch;
+                    self.schedule_irq_reload = false;
+                } else if self.irq_counter == 0 {
+                    self.irq_counter = self.irq_latch;
+                } else {
+                    self.irq_counter -= 1;
+                }
+
+                if self.irq_counter == 0 && self.irq_enable {
+                    self.trigger_irq = true;
+                }
+            }
+            self.previous_a12 = a12;
+        }
+
+        self.peek(addr)
+    }
+
+    fn peek(&self, addr: u16) -> u8 {
+        if addr <= 0x1FFF {
+            self.chr_mem[self.map_chr(addr) + (addr as usize % 0x400)]
+        } else if 0x6000 <= addr && addr <= 0x7FFF {
+            if self.is_mmc6 {
+                if self.mmc6_ram_enable && addr >= 0x7000 {
+                    let mirrored = (addr - 0x7000) % 0x400;
+                    if (mirrored < 0x200 && self.mmc6_ram_lo_read)
+                        || (mirrored >= 0x200 && self.mmc6_ram_hi_read)
+                    {
+                        self.prg_ram[mirrored as usize]
+                    } else {
+                        0
+                    }
+                } else {
+                    0
+                }
+            } else {
+                if self.prg_ram_enable {
+                    self.prg_ram[addr as usize - 0x6000]
+                } else {
+                    0
+                }
+            }
+        } else if addr >= 0x8000 {
+            self.prg_rom[self.map_prg(addr) + (addr as usize % 0x2000)]
+        } else {
+            0
+        }
+    }
+
+    fn write(&mut self, addr: u16, data: u8) {
+        let even = (addr % 2) == 0;
+        if addr <= 0x1FFF {
+            if self.chr_mem_is_ram {
+                let mapped_addr = self.map_chr(addr) + (addr as usize % 0x400);
+                self.chr_mem[mapped_addr] = data;
+            }
+        } else if 0x6000 <= addr && addr <= 0x7FFF {
+            if self.is_mmc6 {
+                if self.mmc6_ram_enable && addr >= 0x7000 {
+                    let mirrored = (addr - 0x7000) % 0x400;
+                    if (mirrored < 0x200 && self.mmc6_ram_lo_write)
+                        || (mirrored >= 0x200 && self.mmc6_ram_hi_write)
+                    {
+                        self.prg_ram[mirrored as usize] = data;
+                    }
+                }
+            } else {
+                if self.prg_ram_enable && !self.write_protection {
+                    self.prg_ram[addr as usize - 0x6000] = data;
+                }
+            }
+        } else if 0x8000 <= addr && addr <= 0x9FFF {
+            if even {
+                // Bank select
+                self.select_bank_register = data & 0b111;
+
+                if self.is_mmc6 {
+                    self.mmc6_ram_enable = ((data >> 5) & 1) == 1;
+                }
+
+                self.prg_bank_mode = ((data >> 6) & 1) == 1;
+                self.chr_bank_mode = ((data >> 7) & 1) == 1;
+            } else {
+                // Bank data
+                self.bank_registers[self.select_bank_register as usize] = data;
+            }
+        } else if 0xA000 <= addr && addr <= 0xBFFF {
+            if even {
+                // Mirroring
+                self.mirroring = if data & 1 == 0 {
+                    Mirroring::Vertical
+                } else {
+                    Mirroring::Horizontal
+                };
+            } else {
+                // PRG RAM protect
+                if self.is_mmc6 {
+                    if self.mmc6_ram_enable {
+                        self.mmc6_ram_lo_write = ((data >> 4) & 1) == 1;
+                        self.mmc6_ram_lo_read = ((data >> 5) & 1) == 1;
+                        self.mmc6_ram_hi_write = ((data >> 6) & 1) == 1;
+                        self.mmc6_ram_hi_read = ((data >> 7) & 1) == 1;
+                    }
+                } else {
+                    self.write_protection = ((data >> 6) & 1) == 1;
+                    self.prg_ram_enable = ((data >> 7) & 1) == 1;
+                }
+            }
+        } else if 0xC000 <= addr && addr <= 0xDFFF {
+            if even {
+                // IRQ latch
+                self.irq_latch = data;
+            } else {
+                // IRQ reload
+                self.schedule_irq_reload = true;
+            }
+        } else if 0xE000 <= addr {
+            self.irq_enable = !even;
+        }
+    }
+}

--- a/nes/src/cartridge/mapper/mapper7.rs
+++ b/nes/src/cartridge/mapper/mapper7.rs
@@ -1,0 +1,55 @@
+use crate::cartridge::Mapper;
+use crate::cartridge::Mirroring;
+use memory::Memory;
+
+// https://wiki.nesdev.com/w/index.php/INES_Mapper_003
+pub struct Mapper7 {
+    n_prg_banks: u16,
+    prg_rom: Vec<u8>,
+    chr_ram: Vec<u8>,
+    prg_bank: u8,
+    mirroring: Mirroring,
+}
+
+impl Mapper for Mapper7 {}
+
+impl Mapper7 {
+    pub fn new(n_prg_banks: u16, prg_data: Vec<u8>) -> Self {
+        Self {
+            n_prg_banks: n_prg_banks,
+            prg_rom: prg_data,
+            chr_ram: vec![0; 0x2000],
+            prg_bank: 0,
+            mirroring: Mirroring::SingleScreenLower,
+        }
+    }
+}
+
+impl Memory for Mapper7 {
+    fn read(&mut self, addr: u16) -> u8 {
+        self.peek(addr)
+    }
+
+    fn peek(&self, addr: u16) -> u8 {
+        if addr <= 0x1FFF {
+            self.chr_ram[addr as usize]
+        } else if 0x8000 <= addr {
+            self.prg_rom[0x8000 * self.prg_bank as usize + (addr as usize - 0x8000)]
+        } else {
+            0x0
+        }
+    }
+
+    fn write(&mut self, addr: u16, data: u8) {
+        if addr <= 0x1FFF {
+            self.chr_ram[addr as usize] = data;
+        } else if addr >= 0x8000 {
+            self.mirroring = if (data >> 4) & 1 == 1 {
+                Mirroring::SingleScreenUpper
+            } else {
+                Mirroring::SingleScreenLower
+            };
+            self.prg_bank = (data & 0b111) % (self.n_prg_banks as u8 / 2);
+        }
+    }
+}

--- a/nes/src/cartridge/mapper/mod.rs
+++ b/nes/src/cartridge/mapper/mod.rs
@@ -3,9 +3,13 @@ use memory::Memory;
 
 mod mapper0;
 mod mapper1;
+mod mapper2;
+mod mapper3;
 
 pub use self::mapper0::Mapper0;
 pub use self::mapper1::Mapper1;
+pub use self::mapper2::Mapper2;
+pub use self::mapper3::Mapper3;
 
 pub trait Mapper: Memory {
     fn get_nametable_mirroring(&self) -> Option<Mirroring> {

--- a/nes/src/cartridge/mapper/mod.rs
+++ b/nes/src/cartridge/mapper/mod.rs
@@ -5,15 +5,21 @@ mod mapper0;
 mod mapper1;
 mod mapper2;
 mod mapper3;
+mod mapper4;
 
 pub use self::mapper0::Mapper0;
 pub use self::mapper1::Mapper1;
 pub use self::mapper2::Mapper2;
 pub use self::mapper3::Mapper3;
+pub use self::mapper4::Mapper4;
 
 pub trait Mapper: Memory {
     fn get_nametable_mirroring(&self) -> Option<Mirroring> {
         None // Unless otherwise specified, mirroring is hard-wired
+    }
+
+    fn check_irq(&mut self) -> bool {
+        false
     }
 
     fn cycle(&mut self) {}

--- a/nes/src/cartridge/mapper/mod.rs
+++ b/nes/src/cartridge/mapper/mod.rs
@@ -6,12 +6,14 @@ mod mapper1;
 mod mapper2;
 mod mapper3;
 mod mapper4;
+mod mapper7;
 
 pub use self::mapper0::Mapper0;
 pub use self::mapper1::Mapper1;
 pub use self::mapper2::Mapper2;
 pub use self::mapper3::Mapper3;
 pub use self::mapper4::Mapper4;
+pub use self::mapper7::Mapper7;
 
 pub trait Mapper: Memory {
     fn get_nametable_mirroring(&self) -> Option<Mirroring> {

--- a/nes/src/cartridge/mod.rs
+++ b/nes/src/cartridge/mod.rs
@@ -47,6 +47,13 @@ impl Cartridge {
             1 => Box::from(Mapper1::new(n_prg_banks, n_chr_banks, prg_data, chr_data)),
             2 => Box::from(Mapper2::new(n_prg_banks, prg_data)),
             3 => Box::from(Mapper3::new(n_chr_banks, prg_data, chr_data)),
+            4 => Box::from(Mapper4::new(
+                n_prg_banks,
+                n_chr_banks,
+                prg_data,
+                chr_data,
+                meta.submapper_num == 1,
+            )),
             _ => return Err("unsupported mapper"),
         };
 
@@ -62,10 +69,20 @@ impl Cartridge {
         } else {
             Mirroring::Horizontal
         };
-        if let Some(some_mapper) = &self.mapper {
+        if default == Mirroring::FourScreen {
+            default
+        } else if let Some(some_mapper) = &self.mapper {
             some_mapper.get_nametable_mirroring().unwrap_or(default)
         } else {
             default
+        }
+    }
+
+    pub fn check_irq(&mut self) -> bool {
+        if let Some(some_mapper) = &mut self.mapper {
+            some_mapper.check_irq()
+        } else {
+            false
         }
     }
 

--- a/nes/src/cartridge/mod.rs
+++ b/nes/src/cartridge/mod.rs
@@ -7,9 +7,7 @@ use cartridge_metadata::CartridgeMetadata;
 pub use cartridge_metadata::Mirroring;
 
 mod mapper;
-use mapper::Mapper;
-use mapper::Mapper0;
-use mapper::Mapper1;
+use mapper::*;
 
 pub struct Cartridge {
     meta: Option<CartridgeMetadata>,
@@ -47,6 +45,8 @@ impl Cartridge {
         let mapper: Box<dyn Mapper> = match meta.mapper_num {
             0 => Box::from(Mapper0::new(n_prg_banks, n_chr_banks, prg_data, chr_data)),
             1 => Box::from(Mapper1::new(n_prg_banks, n_chr_banks, prg_data, chr_data)),
+            2 => Box::from(Mapper2::new(n_prg_banks, prg_data)),
+            3 => Box::from(Mapper3::new(n_chr_banks, prg_data, chr_data)),
             _ => return Err("unsupported mapper"),
         };
 

--- a/nes/src/cartridge/mod.rs
+++ b/nes/src/cartridge/mod.rs
@@ -54,6 +54,7 @@ impl Cartridge {
                 chr_data,
                 meta.submapper_num == 1,
             )),
+            7 => Box::from(Mapper7::new(n_prg_banks, prg_data)),
             _ => return Err("unsupported mapper"),
         };
 

--- a/nes/src/lib.rs
+++ b/nes/src/lib.rs
@@ -98,6 +98,8 @@ impl NES {
         if self.ppu.borrow().nmi {
             self.ppu.borrow_mut().nmi = false;
             self.cpu.borrow_mut().nmi();
+        } else if self.cart.borrow_mut().check_irq() {
+            self.cpu.borrow_mut().irq();
         }
     }
 

--- a/sdl-ui/src/main.rs
+++ b/sdl-ui/src/main.rs
@@ -49,8 +49,7 @@ fn main() {
         .build()
         .unwrap();
 
-    let mut canvas = window.into_canvas().present_vsync().build().unwrap();
-    // let mut canvas = window.into_canvas().build().unwrap();
+    let mut canvas = window.into_canvas().build().unwrap();
     canvas.set_scale(3.0, 3.0).unwrap();
     let mut event_pump = sdl_context.event_pump().unwrap();
 


### PR DESCRIPTION
- Several fixes to mappers 0 and 1
    - Support for mapper 0 with CHR RAM
    - Support for larger ROM sizes by replacing `ROM` struct with `Vec`
- Adds mapper 2, 3, 4, and 7
    - This opens up a huge portion of the NES library (a vast majority, as far as I can tell)
- Add IRQ support to CPU
- Minor PPU scan and register fixes

TODO: There are some sneaky PPU scan bugs, seemingly coming down to sprite fetching and NMI timing, that mess up several games. Notable examples are "Wizards and Warriors" and "Battletoads", both mapper 7 games. This could have to do with a lack of sub-instruction cycle accuracy in the CPU, or a number of other minor timing bugs.