### PR TITLE
Cross-platform SDL UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "sdl-frontend"
+name = "sdl-ui"
 version = "0.1.0"
 dependencies = [
  "nes",
@@ -307,7 +307,7 @@ dependencies = [
  "native-windows-gui",
  "nes",
  "rand",
- "sdl-frontend",
+ "sdl-ui",
  "sdl2",
  "sdl2-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
     "ppu",
     "apu",
     "memory",
-    "sdl-frontend",
+    "sdl-ui",
     "windows-ui",
 ]
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# KindNES
+KindNES is a reasonably accurate NES emulator written in Rust. It strives for portability, performance, and a balance of hardware accuracy and codebase clarity. The code should pair well with [NESdev](https://wiki.nesdev.com/) as a resource for learning about the NES.
+
+# Downloads
+*WIP*
+
+Downloads will be available via Github releases as soon as all platforms have a packaged MVP.
+
+# Building
+## Dependencies
+Both the Windows and cross-platform frontends require Rust-SDL2. To build the frontends, first check out the dependency instructions here: https://github.com/Rust-SDL2/rust-sdl2#sdl20-development-libraries
+
+## Windows
+To run the native Windows frontend, run:
+
+`cargo run --release --bin windows-ui`
+
+To build a binary, run:
+
+`cargo build --release --bin windows-ui`
+
+This should produce a `.exe` file in `target/release/`. Place SDL2.dll from the runtime binary [here](https://www.libsdl.org/download-2.0.php) in the same directory as the exe.
+
+
+## Linux, MacOS, etc.
+To run the cross-platform frontend, run:
+
+`cargo run --release --bin sdl-ui <NES ROM file>`
+
+Replacing `<NES ROM file>` with a `.nes` file.
+
+To build a binary, run:
+
+`cargo build --release --bin sdl-ui`
+
+This should produce an executable file in `target/release/`.
+
+# Progress
+KindNES supports most of the common NES mappers, meaning that it supports the majority of licensed titles. Most supported games run smoothly with minimal glitches. The basic gameplay experience is in a semi-complete state, so progress moving forward will add UI/UX improvements and improved game/peripheral support.
+
+## Next steps
+- Improved UI
+    - More menubar features
+        - Pause, (soft/hard) reset
+    - An improved cross-platform UI with the same menubar features as the Windows version
+        - First priority: Centralize basic features like [file dialogs](https://github.com/EmbarkStudios/nfd2) to sdl-ui shortcuts
+        - Still looking for a GUI framework with great menubar support and SDL2 integration
+- Saving
+    - Safe panic handler that displays an error message and autosaves
+
+## Eventual goals
+- More mappers
+- Speed control
+    - First, get perfect FPS control (it currently sleeps slightly too long at the end of frames)
+    - Variable audio sample rate
+- Controls
+    - Gamepad support
+    - Modifiable controls
+    - Local multiplayer?
+
+## Stretch goals
+- Web version (likely using WebAssembly)
+- Mobile versions (possibly merged with web version?)
+- Netplay
+- Better hardware accuracy
+    - Automated validation with test ROMs
+- Video filters
+- Extended controller support
+    - Popup windows for R.O.B., etc.
+    - Light gun with mouse
+- Debug features
+    - PPU viewer
+    - Sound channel mixer
+    - Step-in debugger
+        - A GDB-style command prompt would be awesome
+- Cheats

--- a/apu/src/channels/dmc_channel.rs
+++ b/apu/src/channels/dmc_channel.rs
@@ -4,7 +4,6 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 // https://wiki.nesdev.com/w/index.php/APU_DMC
-// TODO: Make fewer fields pub in all these structs
 pub struct DMCChannel {
     enabled: bool,
     even_latch: bool,

--- a/cpu/src/instruction.rs
+++ b/cpu/src/instruction.rs
@@ -88,6 +88,7 @@ lazy_static! {
         add("TYA", vec![(0x98, IMP, 2)]);
 
         // https://wiki.nesdev.com/w/index.php/CPU_unofficial_opcodes
+        // TODO: http://visual6502.org/wiki/index.php?title=6502_Opcode_8B_%28XAA,_ANE%29
         add("*NOP", vec![(0x80, IMM, 2),
                         (0x82, IMM, 2), (0xC2, IMM, 2), (0xE2, IMM, 2),
                         (0x04, ZER, 3), (0x44, ZER, 3), (0x64, ZER, 3),

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -33,7 +33,7 @@ pub struct CPU {
 
     pc: u16, // Program counter
     wait_cycles: u32,
-    cycles: usize,
+    cycles: u64,
     pub log: bool,
 
     memory: Box<dyn Memory>,

--- a/nes/src/cartridge/cartridge_metadata.rs
+++ b/nes/src/cartridge/cartridge_metadata.rs
@@ -23,6 +23,7 @@ pub struct CartridgeMetadata {
 
 impl CartridgeMetadata {
     pub fn from_header(header: Vec<u8>) -> Result<Self, &'static str> {
+        // TODO: Some garbage data in iNES 1.0 headers breaks this parsing
         if header[0..=3] != [b'N', b'E', b'S', 0x1A] {
             return Err("header does not begin with NES<EOF> identifier");
         }

--- a/nes/src/cartridge/mapper/mapper1.rs
+++ b/nes/src/cartridge/mapper/mapper1.rs
@@ -99,7 +99,8 @@ impl Memory for Mapper1 {
                 0x1000 * (self.chr_bank_0 as usize)
             };
 
-            return self.chr_mem[base + (addr as usize)];
+            let len = self.chr_mem.len();
+            self.chr_mem[(base + (addr as usize)) % len]
         } else if 0x1000 <= addr && addr <= 0x1FFF {
             let chr_bank_mode = self.control_register >> 4;
             let base = if chr_bank_mode == 0 {
@@ -108,7 +109,8 @@ impl Memory for Mapper1 {
                 0x1000 * (self.chr_bank_1 as usize)
             };
 
-            self.chr_mem[base + ((addr as usize) - 0x1000)]
+            let len = self.chr_mem.len();
+            self.chr_mem[(base + ((addr as usize) - 0x1000)) % len]
         } else if 0x8000 <= addr && addr <= 0xBFFF {
             let prg_bank_mode = (self.control_register & 0b1100) >> 2;
             let base = if prg_bank_mode == 0 || prg_bank_mode == 1 {
@@ -143,7 +145,8 @@ impl Memory for Mapper1 {
                 0x1000 * (self.chr_bank_0 as usize)
             };
 
-            self.chr_mem[base + (addr as usize)] = data;
+            let len = self.chr_mem.len();
+            self.chr_mem[(base + (addr as usize)) % len] = data;
             return;
         } else if 0x1000 <= addr && addr <= 0x1FFF && self.chr_mem_is_ram {
             let chr_bank_mode = self.control_register >> 4;
@@ -153,7 +156,8 @@ impl Memory for Mapper1 {
                 0x1000 * (self.chr_bank_1 as usize)
             };
 
-            self.chr_mem[base + ((addr as usize) - 0x1000)] = data;
+            let len = self.chr_mem.len();
+            self.chr_mem[(base + ((addr as usize) - 0x1000)) % len] = data;
             return;
         } else if 0x4020 <= addr && addr <= 0x5FFF {
             return;

--- a/nes/src/cartridge/mapper/mapper7.rs
+++ b/nes/src/cartridge/mapper/mapper7.rs
@@ -2,7 +2,7 @@ use crate::cartridge::Mapper;
 use crate::cartridge::Mirroring;
 use memory::Memory;
 
-// https://wiki.nesdev.com/w/index.php/INES_Mapper_003
+// https://wiki.nesdev.com/w/index.php/AxROM
 pub struct Mapper7 {
     n_prg_banks: u16,
     prg_rom: Vec<u8>,
@@ -11,7 +11,11 @@ pub struct Mapper7 {
     mirroring: Mirroring,
 }
 
-impl Mapper for Mapper7 {}
+impl Mapper for Mapper7 {
+    fn get_nametable_mirroring(&self) -> Option<Mirroring> {
+        Some(self.mirroring)
+    }
+}
 
 impl Mapper7 {
     pub fn new(n_prg_banks: u16, prg_data: Vec<u8>) -> Self {

--- a/nes/src/cartridge/mapper/mapper9.rs
+++ b/nes/src/cartridge/mapper/mapper9.rs
@@ -19,7 +19,11 @@ pub struct Mapper9 {
     mirroring: Mirroring,
 }
 
-impl Mapper for Mapper9 {}
+impl Mapper for Mapper9 {
+    fn get_nametable_mirroring(&self) -> Option<Mirroring> {
+        Some(self.mirroring)
+    }
+}
 
 impl Mapper9 {
     pub fn new(n_prg_banks: u16, prg_data: Vec<u8>, chr_data: Vec<u8>) -> Self {

--- a/ppu/src/lib.rs
+++ b/ppu/src/lib.rs
@@ -292,7 +292,12 @@ impl PPU {
 
                 let flip_v = self.oam2[4 * (spr_num as usize) + 2] >> 7 == 1;
                 if flip_v {
-                    y = self.registers.ppuctrl.get_sprite_height() - 1 - y;
+                    y = self
+                        .registers
+                        .ppuctrl
+                        .get_sprite_height()
+                        .wrapping_sub(1)
+                        .wrapping_sub(y);
                 }
                 if self
                     .registers

--- a/ppu/src/lib.rs
+++ b/ppu/src/lib.rs
@@ -76,7 +76,9 @@ impl PPU {
             if self.scan.on_idle_cycle() {
                 // Idle
             } else if self.scan.on_bg_fetch_cycle() {
-                self.bg_fetch((self.scan.cycle - 1) % 8);
+                if self.registers.ppumask.is_rendering() {
+                    self.bg_fetch((self.scan.cycle - 1) % 8);
+                }
             } else if self.scan.cycle == 257 && self.registers.ppumask.is_rendering() {
                 // https://wiki.nesdev.com/w/index.php/PPU_scrolling#At_dot_257_of_each_scanline
                 self.registers
@@ -84,7 +86,11 @@ impl PPU {
                     .copy_horizontal(&self.registers.temp_addr);
             }
 
-            if self.scan.on_spr_fetch_cycle() {
+            if self.scan.cycle == 257 {
+                self.spr_data.spr_nums = self.spr_data.spr_nums_next;
+            }
+
+            if self.scan.on_spr_fetch_cycle() && self.registers.ppumask.is_rendering() {
                 self.spr_fetch((self.scan.cycle - 257) / 8, (self.scan.cycle - 1) % 8);
             }
         }
@@ -254,7 +260,8 @@ impl PPU {
                 // Garbage nametable byte
             }
             2 => {
-                self.spr_data.registers[spr_num as usize].num = spr_num;
+                self.spr_data.registers[spr_num as usize].num =
+                    self.spr_data.spr_nums[spr_num as usize] as u16;
                 self.spr_data.registers[spr_num as usize].attr_latch =
                     self.oam2[4 * (spr_num as usize) + 2];
             }
@@ -276,7 +283,10 @@ impl PPU {
                     }
                 }
                 if !any_good {
+                    self.spr_data.registers[spr_num as usize].is_dummy = true;
                     y = 0;
+                } else {
+                    self.spr_data.registers[spr_num as usize].is_dummy = false;
                 }
 
                 let mut tile_index = self.oam2[4 * (spr_num as usize) + 1] as u16;
@@ -336,6 +346,8 @@ impl PPU {
                 let y = self.oam[4 * self.spr_data.spr_num as usize] as u16;
                 if self.spr_data.oam2_index < 8 {
                     self.oam2[4 * self.spr_data.oam2_index as usize] = y as u8;
+                    self.spr_data.spr_nums_next[self.spr_data.oam2_index as usize] =
+                        self.spr_data.spr_num;
                     if y <= self.scan.line
                         && self.scan.line
                             < y.wrapping_add(self.registers.ppuctrl.get_sprite_height())
@@ -454,7 +466,7 @@ impl PPU {
         // https://wiki.nesdev.com/w/index.php/PPU_rendering#Preface
         let mut pixel_option = None;
         for sprite_registers in &mut self.spr_data.registers {
-            if sprite_registers.x_counter != 0 {
+            if sprite_registers.x_counter != 0 || sprite_registers.is_dummy {
                 continue;
             }
 

--- a/ppu/src/scan.rs
+++ b/ppu/src/scan.rs
@@ -1,8 +1,8 @@
 pub struct Scan {
     pub line: u16,
     pub cycle: u16,
-    pub total_cycles: u32,
-    pub total_frames: u32,
+    pub total_cycles: u64,
+    pub total_frames: u64,
     odd_frame: bool,
 }
 

--- a/ppu/src/sprite_data.rs
+++ b/ppu/src/sprite_data.rs
@@ -2,10 +2,12 @@
 pub struct SpriteData {
     pub registers: [SpriteRegisters; 8],
     pub eval_state: SpriteEvalState,
-    pub spr_num: u8,    // "sprite n (0-63)"
-    pub byte_num: u8,   // "byte m (0-3)"
-    pub oam_byte: u8,   // Filled on odd cycles
-    pub oam2_index: u8, // Number of sprites found on this line.
+    pub spr_nums: [u8; 8],      // The OAM sprite indices of each OAM2 sprite
+    pub spr_nums_next: [u8; 8], // The indices of sprites being evaluated
+    pub spr_num: u8,            // "sprite n (0-63)"
+    pub byte_num: u8,           // "byte m (0-3)"
+    pub oam_byte: u8,           // Filled on odd cycles
+    pub oam2_index: u8,         // Number of sprites found on this line.
 }
 
 impl SpriteData {
@@ -13,6 +15,8 @@ impl SpriteData {
         Self {
             registers: [SpriteRegisters::new(); 8],
             eval_state: SpriteEvalState::CopyY,
+            spr_nums: [0xFF; 8],
+            spr_nums_next: [0xFF; 8],
             spr_num: 0,
             byte_num: 0,
             oam_byte: 0,
@@ -22,6 +26,8 @@ impl SpriteData {
 
     pub fn reset(&mut self) {
         self.eval_state = SpriteEvalState::CopyY;
+        self.spr_nums = [0xFF; 8];
+        self.spr_nums_next = [0xFF; 8];
         self.spr_num = 0;
         self.byte_num = 0;
         self.oam_byte = 0;
@@ -35,6 +41,7 @@ pub struct SpriteRegisters {
     pub patt_shift: [u8; 2],
     pub attr_latch: u8,
     pub x_counter: u8,
+    pub is_dummy: bool,
 }
 
 impl SpriteRegisters {
@@ -44,6 +51,7 @@ impl SpriteRegisters {
             patt_shift: [0; 2],
             attr_latch: 0,
             x_counter: 0,
+            is_dummy: false,
         }
     }
 }

--- a/sdl-ui/Cargo.toml
+++ b/sdl-ui/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sdl-frontend"
+name = "sdl-ui"
 version = "0.1.0"
 authors = ["Henry Sloan <henryksloan@gmail.com>"]
 edition = "2018"

--- a/sdl-ui/src/lib.rs
+++ b/sdl-ui/src/lib.rs
@@ -24,13 +24,13 @@ const COLORS: &'static [i32] = &[
     0x000000,
 ];
 
-pub struct SDLFrontend {
+pub struct SDLUI {
     sdl_context: Sdl,
     canvas: WindowCanvas,
     nes: Rc<RefCell<NES>>,
 }
 
-impl SDLFrontend {
+impl SDLUI {
     pub fn new(sdl_context: Sdl, window: Window, nes: Rc<RefCell<NES>>) -> Self {
         Self {
             sdl_context,

--- a/sdl-ui/src/main.rs
+++ b/sdl-ui/src/main.rs
@@ -1,0 +1,38 @@
+use nes::NES;
+
+use std::cell::RefCell;
+use std::env;
+use std::fs::File;
+use std::process;
+use std::rc::Rc;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("usage: {} <NES ROM file>", args[0]);
+        process::exit(1);
+    }
+
+    let file = File::open(&args[1]).unwrap_or_else(|err| {
+        println!("failed to read file: {}", err);
+        process::exit(1);
+    });
+
+    let mut nes = Rc::new(RefCell::new(NES::new()));
+    nes.borrow_mut().load_rom(file).unwrap_or_else(|err| {
+        println!("failed to load ROM: {}", err);
+        process::exit(1);
+    });
+
+    let sdl_context = sdl2::init().unwrap();
+    let video_subsystem = sdl_context.video().unwrap();
+
+    let window = video_subsystem
+        .window("KindNES", (256.0 * 3.0) as u32, (240.0 * 3.0) as u32)
+        .position_centered()
+        .build()
+        .unwrap();
+
+    let mut sdl_ui = sdl_ui::SDLUI::new(sdl_context, window, nes);
+    sdl_ui.render_loop();
+}

--- a/sdl-ui/src/main.rs
+++ b/sdl-ui/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
         process::exit(1);
     });
 
-    let mut nes = Rc::new(RefCell::new(NES::new()));
+    let nes = Rc::new(RefCell::new(NES::new()));
     nes.borrow_mut().load_rom(file).unwrap_or_else(|err| {
         println!("failed to load ROM: {}", err);
         process::exit(1);

--- a/windows-ui/Cargo.toml
+++ b/windows-ui/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 nes = { path = "../nes" }
 cpu = { path = "../cpu" }
 memory = { path = "../memory" }
-sdl-frontend = { path = "../sdl-frontend" }
+sdl-ui = { path = "../sdl-ui" }
 sdl2 = "0.34.3"
 sdl2-sys = "0.34.3"
 rand = "0.8.3"

--- a/windows-ui/src/main.rs
+++ b/windows-ui/src/main.rs
@@ -1,7 +1,7 @@
 #![windows_subsystem = "windows"]
 
 use nes::NES;
-use sdl_frontend::SDLFrontend;
+use sdl_ui::SDLUI;
 
 use core::ffi::c_void;
 use std::cell::RefCell;
@@ -107,6 +107,6 @@ fn main() {
         SDL_Window::from_ll(video_subsystem, window_raw)
     };
 
-    let mut sdl_frontend = SDLFrontend::new(sdl_context, window, app.nes.clone());
-    sdl_frontend.render_loop();
+    let mut sdl_ui = SDLUI::new(sdl_context, window, app.nes.clone());
+    sdl_ui.render_loop();
 }


### PR DESCRIPTION
- Adds a binary to the `sdl-ui` crate, adding a minimal wrapper for the SDL gameplay loop
- Fixes various overflow and mapper bugs
    - Increase integer sizes and add `.wrapping_*` to various operations
    - Completes some important mapper functions I missed, namely mapper-controlled mirroring on mappers 7 and 9
        - This fixes "Mike Tyson's Punch-Out!!" and "Wizards & Warriors"
        - Also makes Battletoads fail in a more actionable way
    - Fixes some bit operations in mapper 1
- Substantial improvements to PPU
    - Fixes sprite-zero hit
        - Previously, it had been numbering sprites based on their render order in the scanline, i.e. their order in secondary OAM
        - Now, sprite evaluation keeps a log of sprite numbers from *primary* OAM, which is then copied and used for sprite fetching
        - Fixes "Excitebike" track rendering, which previously used the *player* as sprite zero
- Adds an initial detailed README