### PR TITLE
Gamepad support and UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ KindNES is a reasonably accurate NES emulator written in Rust. It strives for po
 ### Usage
 Either give a .NES ROM file as a command line argument, or use the File > Open ROM menu bar option (currently only on the Windows version).
 
-| Button | Key |
-| --- | --- |
-| D-Pad | Arrow keys |
-| A button | X |
-| B button | Z |
-| Start | Enter |
-| Select | Right shift |
+| Button | Key | Gamepad |
+| --- | --- | --- |
+| D-Pad | Arrow keys | D-Pad or joystick |
+| A button | X | A (Playstation X) |
+| B button | Z | B (Playstation O) |
+| Start | Enter | Start |
+| Select | Right shift | Select |
 
 # Downloads
 Downloads can be found on the [releases page](https://github.com/henryksloan/kind-nes/releases). Currently, only the Windows version is packaged, so users of other platforms should build KindNES as described below. There are plans for Linux (AppImage) packages in the near future, and eventually MacOS packages.
@@ -50,7 +50,6 @@ KindNES supports most of the common NES mappers, meaning that it supports the ma
 ## Next steps
 - Improved UI
     - More menubar features
-        - Pause, (soft/hard) reset
     - An improved cross-platform UI with the same menubar features as the Windows version
         - First priority: Centralize basic features like [file dialogs](https://github.com/EmbarkStudios/nfd2) to sdl-ui shortcuts
         - Still looking for a GUI framework with great menubar support and SDL2 integration
@@ -63,7 +62,6 @@ KindNES supports most of the common NES mappers, meaning that it supports the ma
     - First, get perfect FPS control (it currently sleeps slightly too long at the end of frames)
     - Variable audio sample rate
 - Controls
-    - Gamepad support
     - Modifiable controls
     - Local multiplayer?
 
@@ -82,5 +80,6 @@ KindNES supports most of the common NES mappers, meaning that it supports the ma
     - Sound channel mixer
     - Step-in debugger
         - A GDB-style command prompt would be awesome
+- Distinguish between hard and soft reset
 - Cheats
 - TAS creation

--- a/cpu/src/instruction.rs
+++ b/cpu/src/instruction.rs
@@ -88,7 +88,6 @@ lazy_static! {
         add("TYA", vec![(0x98, IMP, 2)]);
 
         // https://wiki.nesdev.com/w/index.php/CPU_unofficial_opcodes
-        // TODO: http://visual6502.org/wiki/index.php?title=6502_Opcode_8B_%28XAA,_ANE%29
         add("*NOP", vec![(0x80, IMM, 2),
                         (0x82, IMM, 2), (0xC2, IMM, 2), (0xE2, IMM, 2),
                         (0x04, ZER, 3), (0x44, ZER, 3), (0x64, ZER, 3),
@@ -115,7 +114,7 @@ lazy_static! {
         add("*ARR", vec![(0x6B, IMM, 2)]);
         add("*SAX", vec![(0x83, INX, 6), (0x87, ZER, 3), (0x8F, ABS, 4), (0x97, ZEY, 4)]);
         add("*SBC", vec![(0xEB, IMM, 2)]);
-        add("*LAX", vec![(0xA3, INX, 6), (0xA7, ZER, 3), (0xAB, IMM, 4), (0xAF, ABS, 4),
+        add("*LAX", vec![(0xA3, INX, 6), (0xA7, ZER, 3), (0xAB, IMM, 2), (0xAF, ABS, 4),
                         (0xB3, INY, 5), (0xB7, ZEY, 4), (0xBF, ABY, 4)]);
         add("*LAS", vec![(0xBB, ABY, 4)]);
         add("*DCP", vec![(0xC3, INX, 8), (0xC7, ZER, 5), (0xCF, ABS, 6), (0xD3, INY, 8),
@@ -127,6 +126,8 @@ lazy_static! {
         add("*SHY", vec![(0x9C, ABX, 5)]);
         add("*AXA", vec![(0x93, INY, 6), (0x9F, ABX, 5)]);
         add("*AXS", vec![(0xCB, IMM, 2)]);
+        add("*XAA", vec![(0x8B, IMM, 2)]);
+        add("*TAS", vec![(0x9B, ABY, 5)]);
         map
     };
 }

--- a/nes/src/cartridge/cartridge_metadata.rs
+++ b/nes/src/cartridge/cartridge_metadata.rs
@@ -1,5 +1,7 @@
+// https://wiki.nesdev.com/w/index.php/INES
 // https://wiki.nesdev.com/w/index.php/NES_2.0#Header
 pub struct CartridgeMetadata {
+    pub is_nes2: bool,
     pub n_prg_banks: u16,
     pub n_chr_banks: u16,
     pub hardwired_mirroring: Mirroring,
@@ -8,28 +10,28 @@ pub struct CartridgeMetadata {
     pub mapper_num: u16,
 
     // Uncommon features
-    pub submapper_num: u16,
+    pub submapper_num: Option<u16>,
     pub console_type: ConsoleType,
-    pub prg_ram_shifts: u8,
-    pub prg_nvram_shifts: u8,
-    pub chr_ram_shifts: u8,
-    pub chr_nvram_shifts: u8,
+    pub prg_ram_bytes: usize,
+    pub prg_nvram_bytes: usize,
+    pub chr_ram_bytes: usize,
+    pub chr_nvram_bytes: usize,
     pub timing: ClockTiming,
-    pub vs_system_type: u8,
-    pub extended_console_type: u8,
-    pub n_misc_roms: u8,
-    pub default_expansion_device: u8,
+    pub vs_system_type: Option<u8>,
+    pub n_misc_roms: Option<u8>,
+    pub default_expansion_device: Option<u8>,
 }
 
 impl CartridgeMetadata {
     pub fn from_header(header: Vec<u8>) -> Result<Self, &'static str> {
-        // TODO: Some garbage data in iNES 1.0 headers breaks this parsing
         if header[0..=3] != [b'N', b'E', b'S', 0x1A] {
             return Err("header does not begin with NES<EOF> identifier");
         }
 
-        let n_prg_banks = (((header[9] & 0x0F) as u16) << 8) | (header[4] as u16);
-        let n_chr_banks = (((header[9] & 0xF0) as u16) << 4) | (header[5] as u16);
+        let is_nes2 = (header[7] & 0b1100) == 0b1000;
+
+        let mut n_prg_banks = header[4] as u16;
+        let mut n_chr_banks = header[5] as u16;
 
         let hardwired_mirroring = if ((header[6] >> 3) & 1) == 1 {
             Mirroring::FourScreen
@@ -39,42 +41,108 @@ impl CartridgeMetadata {
                 _ => Mirroring::Vertical,
             }
         };
-
         let has_battery = ((header[6] >> 1) & 1) == 1;
         let has_trainer = ((header[6] >> 2) & 1) == 1;
+        let mut mapper_num = (header[6] >> 4) as u16;
 
-        let mapper_num = ((header[6] >> 4) as u16)
-            | ((header[7] & 0xF0) as u16)
-            | (((header[8] & 0x0F) as u16) << 8);
-        let submapper_num = (header[8] >> 4) as u16;
+        let mut submapper_num = None;
+        let mut timing = ClockTiming::NTSC;
+        let mut vs_system_type = None;
+        let mut n_misc_roms = None;
+        let mut default_expansion_device = None;
 
-        let console_type = match header[7] & 0b11 {
-            0 => ConsoleType::NESFamicom,
-            1 => ConsoleType::VsSystem,
-            2 => ConsoleType::Playchoice10,
-            _ => ConsoleType::Extended,
-        };
+        let (console_type, prg_ram_bytes, prg_nvram_bytes, chr_ram_bytes, chr_nvram_bytes) =
+            if is_nes2 {
+                let console_type = match header[7] & 0b11 {
+                    0 => ConsoleType::NESFamicom,
+                    1 => ConsoleType::VsSystem,
+                    2 => ConsoleType::Playchoice10,
+                    _ => match header[13] & 0b1111 {
+                        0x0 => ConsoleType::NESFamicom,
+                        0x1 => ConsoleType::VsSystem,
+                        0x2 => ConsoleType::Playchoice10,
+                        0x3 => ConsoleType::DecimalFamiclone,
+                        0x4 => ConsoleType::VT01Monochrome,
+                        0x5 => ConsoleType::VT01STN,
+                        0x6 => ConsoleType::VT02,
+                        0x7 => ConsoleType::VT03,
+                        0x8 => ConsoleType::VT09,
+                        0x9 => ConsoleType::VT32,
+                        0xA => ConsoleType::VT369,
+                        0xB => ConsoleType::UM6578,
+                        _ => ConsoleType::Other,
+                    },
+                };
 
-        let prg_ram_shifts = header[10] & 0x0F;
-        let prg_nvram_shifts = (header[10] & 0xF0) >> 4;
-        let chr_ram_shifts = header[11] & 0x0F;
-        let chr_nvram_shifts = (header[11] & 0xF0) >> 4;
+                mapper_num |= ((header[7] & 0xF0) as u16) | (((header[8] & 0x0F) as u16) << 8);
+                submapper_num = Some((header[8] >> 4) as u16);
 
-        let timing = match header[12] & 0b11 {
-            0 => ClockTiming::NTSC,
-            1 => ClockTiming::PAL,
-            2 => ClockTiming::MultiRegion,
-            _ => ClockTiming::Dendy,
-        };
+                n_prg_banks |= ((header[9] & 0x0F) as u16) << 8;
+                n_chr_banks |= ((header[9] & 0xF0) as u16) << 4;
 
-        // TODO: These can be enums
-        let vs_system_type = header[13];
-        let extended_console_type = header[13] & 0x0F;
+                let prg_ram_bytes = 64usize << (header[10] & 0x0F);
+                let prg_nvram_bytes = 64usize << ((header[10] & 0xF0) >> 4);
+                let chr_ram_bytes = 64usize << (header[11] & 0x0F);
+                let chr_nvram_bytes = 64usize << ((header[11] & 0xF0) >> 4);
 
-        let n_misc_roms = header[14] & 0b11;
-        let default_expansion_device = header[14] & 0b11_1111;
+                timing = match header[12] & 0b11 {
+                    0 => ClockTiming::NTSC,
+                    1 => ClockTiming::PAL,
+                    2 => ClockTiming::MultiRegion,
+                    _ => ClockTiming::Dendy,
+                };
+
+                // This could be an enum if it's ever used
+                vs_system_type = Some(header[13]);
+
+                n_misc_roms = Some(header[14] & 0b11);
+                default_expansion_device = Some(header[14] & 0b11_1111);
+
+                (
+                    console_type,
+                    prg_ram_bytes,
+                    prg_nvram_bytes,
+                    chr_ram_bytes,
+                    chr_nvram_bytes,
+                )
+            } else {
+                let console_type = match header[7] & 0b11 {
+                    0 => ConsoleType::NESFamicom,
+                    1 => ConsoleType::VsSystem,
+                    _ => ConsoleType::Playchoice10,
+                };
+
+                // Either PRG-RAM or PRG-NVRAM, depending on the battery flag in byte 6
+                let mut some_prg_ram_bytes = 0x2000;
+
+                // "A general rule of thumb: if the last 4 bytes are not all zero, and the header is not marked for NES 2.0 format,
+                // an emulator should either mask off the upper 4 bits of the mapper number or simply refuse to load the ROM."
+                if header[12] == 0 && header[13] == 0 && header[14] == 0 && header[15] == 0 {
+                    mapper_num |= (header[7] & 0xF0) as u16;
+
+                    // "Size of PRG RAM in 8 KB units (Value 0 infers 8 KB for compatibility; see PRG RAM circuit)"
+                    some_prg_ram_bytes *= std::cmp::max(header[8], 1) as usize;
+                }
+
+                let chr_ram_bytes = if n_chr_banks == 0 { 0x2000 } else { 0 };
+
+                let (prg_ram_bytes, prg_nvram_bytes) = if has_battery {
+                    (0, some_prg_ram_bytes)
+                } else {
+                    (some_prg_ram_bytes, 0)
+                };
+
+                (
+                    console_type,
+                    prg_ram_bytes,
+                    prg_nvram_bytes,
+                    chr_ram_bytes,
+                    0,
+                )
+            };
 
         Ok(Self {
+            is_nes2,
             n_prg_banks,
             n_chr_banks,
             hardwired_mirroring,
@@ -83,13 +151,12 @@ impl CartridgeMetadata {
             mapper_num,
             submapper_num,
             console_type,
-            prg_ram_shifts,
-            prg_nvram_shifts,
-            chr_ram_shifts,
-            chr_nvram_shifts,
+            prg_ram_bytes,
+            prg_nvram_bytes,
+            chr_ram_bytes,
+            chr_nvram_bytes,
             timing,
             vs_system_type,
-            extended_console_type,
             n_misc_roms,
             default_expansion_device,
         })
@@ -109,7 +176,16 @@ pub enum ConsoleType {
     NESFamicom,
     VsSystem,
     Playchoice10,
-    Extended,
+    DecimalFamiclone,
+    VT01Monochrome,
+    VT01STN,
+    VT02,
+    VT03,
+    VT09,
+    VT32,
+    VT369,
+    UM6578,
+    Other,
 }
 
 pub enum ClockTiming {

--- a/nes/src/cartridge/mapper/mapper0.rs
+++ b/nes/src/cartridge/mapper/mapper0.rs
@@ -35,8 +35,10 @@ impl Memory for Mapper0 {
     fn peek(&self, addr: u16) -> u8 {
         if addr <= 0x1FFF {
             self.chr_mem[addr as usize % self.chr_mem.len()]
-        } else {
+        } else if addr >= 0x8000 {
             self.prg_rom[((addr as usize - 0x8000) % (self.n_prg_banks as usize * 0x4000))]
+        } else {
+            0
         }
     }
 
@@ -46,7 +48,7 @@ impl Memory for Mapper0 {
                 let len = self.chr_mem.len();
                 self.chr_mem[addr as usize % len] = data;
             }
-        } else {
+        } else if addr >= 0x8000 {
             self.prg_rom[((addr as usize - 0x8000) % (self.n_prg_banks as usize * 0x4000))] = data;
         }
     }

--- a/nes/src/cartridge/mapper/mapper1.rs
+++ b/nes/src/cartridge/mapper/mapper1.rs
@@ -39,7 +39,7 @@ impl Mapper1 {
             control_register: 0b01100, // "MMC1 seems to reliably power on in the last bank"
             chr_bank_0: 0,
             chr_bank_1: 0,
-            prg_bank: 0,
+            prg_bank: 0b10000,
         }
     }
 }
@@ -84,11 +84,7 @@ impl Memory for Mapper1 {
 
     fn peek(&self, addr: u16) -> u8 {
         if 0x6000 <= addr && addr <= 0x7FFF {
-            return if self.prg_bank >> 4 == 0 {
-                self.prg_ram[(addr as usize) - 0x6000]
-            } else {
-                0
-            };
+            return self.prg_ram[(addr as usize) - 0x6000];
         }
 
         if addr <= 0x0FFF {
@@ -169,6 +165,10 @@ impl Memory for Mapper1 {
             if self.prg_bank >> 4 == 0 {
                 self.prg_ram[(addr as usize) - 0x6000] = data;
             }
+            return;
+        }
+
+        if addr < 0x8000 {
             return;
         }
 

--- a/nes/src/cartridge/mapper/mapper1.rs
+++ b/nes/src/cartridge/mapper/mapper1.rs
@@ -196,7 +196,7 @@ impl Memory for Mapper1 {
             } else if 0xC000 <= addr && addr <= 0xDFFF {
                 self.chr_bank_1 = self.shift_register;
             } else {
-                self.prg_bank = self.shift_register;
+                self.prg_bank = (self.shift_register) % (self.n_prg_banks as u8);
             }
             self.shift_register = 0b10000;
             self.shift_write_count = 0;

--- a/nes/src/cartridge/mapper/mapper3.rs
+++ b/nes/src/cartridge/mapper/mapper3.rs
@@ -31,7 +31,8 @@ impl Memory for Mapper3 {
         if addr <= 0x1FFF {
             self.chr_rom[(self.chr_bank as usize * 0x2000) + addr as usize]
         } else if 0x8000 <= addr {
-            self.prg_rom[addr as usize - 0x8000]
+            let len = self.prg_rom.len();
+            self.prg_rom[(addr as usize - 0x8000) % len]
         } else {
             0x0
         }

--- a/nes/src/cartridge/mapper/mapper4.rs
+++ b/nes/src/cartridge/mapper/mapper4.rs
@@ -116,7 +116,7 @@ impl Mapper4 {
             [r6, r7, second_last, last]
         };
 
-        0x2000 * banks[(addr as usize - 0x8000) / 0x2000] as usize
+        0x2000 * (banks[(addr as usize - 0x8000) / 0x2000] % (self.n_prg_banks * 2)) as usize
     }
 }
 

--- a/nes/src/cartridge/mapper/mapper71.rs
+++ b/nes/src/cartridge/mapper/mapper71.rs
@@ -1,0 +1,67 @@
+use crate::cartridge::Mapper;
+use crate::cartridge::Mirroring;
+use memory::Memory;
+
+// https://wiki.nesdev.com/w/index.php/INES_Mapper_071
+pub struct Mapper71 {
+    n_prg_banks: u16,
+    prg_rom: Vec<u8>,
+    chr_mem: Vec<u8>,
+    prg_bank: u8,
+
+    mirroring_option: Option<Mirroring>,
+}
+
+impl Mapper for Mapper71 {
+    fn get_nametable_mirroring(&self) -> Option<Mirroring> {
+        self.mirroring_option
+    }
+}
+
+impl Mapper71 {
+    pub fn new(n_prg_banks: u16, prg_data: Vec<u8>) -> Self {
+        Self {
+            n_prg_banks,
+            chr_mem: vec![0; 0x2000],
+            prg_rom: prg_data,
+            prg_bank: 0,
+
+            mirroring_option: None,
+        }
+    }
+}
+
+impl Memory for Mapper71 {
+    fn read(&mut self, addr: u16) -> u8 {
+        self.peek(addr)
+    }
+
+    fn peek(&self, addr: u16) -> u8 {
+        if addr <= 0x1FFF {
+            self.chr_mem[addr as usize % self.chr_mem.len()]
+        } else if 0x8000 <= addr && addr <= 0xBFFF {
+            self.prg_rom[self.prg_bank as usize * 0x4000 + (addr as usize - 0x8000)]
+        } else if 0xC000 <= addr {
+            self.prg_rom[(self.n_prg_banks as usize - 1) * 0x4000 + (addr as usize - 0xC000)]
+        } else {
+            0x0
+        }
+    }
+
+    fn write(&mut self, addr: u16, data: u8) {
+        if addr <= 0x1FFF {
+            let len = self.chr_mem.len();
+            self.chr_mem[addr as usize % len] = data;
+        } else if 0x9000 <= addr && addr <= 0x9FFF {
+            // "For compatibility without using a submapper, FCEUX begins all games with fixed mirroring,
+            // and applies single screen mirroring only once $9000-9FFF is written, ignoring writes to $8000-8FFF."
+            self.mirroring_option = Some(if (data >> 4) & 1 == 1 {
+                Mirroring::SingleScreenUpper
+            } else {
+                Mirroring::SingleScreenLower
+            });
+        } else if addr >= 0xC000 {
+            self.prg_bank = data % self.n_prg_banks as u8;
+        }
+    }
+}

--- a/nes/src/cartridge/mapper/mod.rs
+++ b/nes/src/cartridge/mapper/mod.rs
@@ -7,6 +7,7 @@ mod mapper2;
 mod mapper3;
 mod mapper4;
 mod mapper7;
+mod mapper71;
 mod mapper9;
 
 pub use self::mapper0::Mapper0;
@@ -15,8 +16,10 @@ pub use self::mapper2::Mapper2;
 pub use self::mapper3::Mapper3;
 pub use self::mapper4::Mapper4;
 pub use self::mapper7::Mapper7;
+pub use self::mapper71::Mapper71;
 pub use self::mapper9::Mapper9;
 
+// TODO: Add reset to more mappers so NES::reset works
 pub trait Mapper: Memory {
     fn get_nametable_mirroring(&self) -> Option<Mirroring> {
         None // Unless otherwise specified, mirroring is hard-wired

--- a/nes/src/cartridge/mod.rs
+++ b/nes/src/cartridge/mod.rs
@@ -52,10 +52,11 @@ impl Cartridge {
                 n_chr_banks,
                 prg_data,
                 chr_data,
-                meta.submapper_num == 1,
+                meta.submapper_num == Some(1),
             )),
             7 => Box::from(Mapper7::new(n_prg_banks, prg_data)),
             9 => Box::from(Mapper9::new(n_prg_banks, prg_data, chr_data)),
+            71 => Box::from(Mapper71::new(n_prg_banks, prg_data)),
             _ => return Err("unsupported mapper"),
         };
 

--- a/nes/src/lib.rs
+++ b/nes/src/lib.rs
@@ -81,6 +81,7 @@ impl NES {
     }
 
     pub fn reset(&mut self) {
+        // TODO: It seems that something isn't resetting, causing some (mainly test) roms to run extremely slowly
         self.cpu.borrow_mut().reset();
         self.ppu.borrow_mut().reset();
         self.apu.borrow_mut().reset();
@@ -126,7 +127,7 @@ impl NES {
         self.cart.borrow_mut().cycle(); // TODO: Probably per-ppu tick for some mappers
         if self.ppu.borrow().nmi {
             self.ppu.borrow_mut().nmi = false;
-            self.cpu.borrow_mut().nmi();
+            self.cpu.borrow_mut().nmi_timer = 2;
         } else if self.cart.borrow_mut().check_irq() || self.apu.borrow_mut().check_irq() {
             self.cpu.borrow_mut().irq();
         }

--- a/nes/src/lib.rs
+++ b/nes/src/lib.rs
@@ -27,6 +27,8 @@ pub struct NES {
     cart: Rc<RefCell<Cartridge>>,
     joy1: Rc<RefCell<dyn Controller>>,
     joy2: Rc<RefCell<dyn Controller>>,
+
+    pub paused: bool,
 }
 
 impl NES {
@@ -74,7 +76,15 @@ impl NES {
             cart,
             joy1,
             joy2,
+            paused: false,
         }
+    }
+
+    pub fn reset(&mut self) {
+        self.cpu.borrow_mut().reset();
+        self.ppu.borrow_mut().reset();
+        self.apu.borrow_mut().reset();
+        self.cart.borrow_mut().reset();
     }
 
     /// Load a ROM from a file and reset the system, returning whether it succeeded
@@ -96,6 +106,10 @@ impl NES {
     }
 
     pub fn tick(&mut self) {
+        if self.paused {
+            return;
+        }
+
         self.ppu.borrow_mut().frame_ready = false;
         if let Some(log) = self.cpu.borrow_mut().tick() {
             println!("{}", log);

--- a/nes/src/nametable_memory.rs
+++ b/nes/src/nametable_memory.rs
@@ -10,11 +10,12 @@ pub struct NametableMemory {
     memory: RAM,
 }
 
+// TODO: I think FourScreen should generally map in part or entirely to cartridge memory
 impl NametableMemory {
     pub fn new(cart: Rc<RefCell<Cartridge>>) -> Self {
         Self {
             cart,
-            memory: RAM::new(0x400 * 4, 0x0000),
+            memory: RAM::new(0x400 * 8, 0x0000),
         }
     }
 
@@ -24,19 +25,15 @@ impl NametableMemory {
         if _addr >= 0x3000 {
             _addr -= 0x1000;
         }
-        let mut fix_4s = 0;
         let nt_mirroring = match self.cart.borrow().get_nametable_mirroring() {
             Mirroring::Vertical => [0, 1, 0, 1],
             Mirroring::Horizontal => [0, 0, 1, 1],
-            Mirroring::FourScreen => {
-                fix_4s = 0x2000;
-                [0, 1, 2, 3]
-            }
+            Mirroring::FourScreen => [0, 1, 2, 3],
             Mirroring::SingleScreenUpper => [1, 1, 1, 1],
             Mirroring::SingleScreenLower => [0, 0, 0, 0],
         };
 
-        nt_mirroring[((_addr - 0x2000) / 0x400) as usize] * 0x400 + (_addr % 0x400) + fix_4s
+        nt_mirroring[((_addr - 0x2000) / 0x400) as usize] * 0x400 + (_addr % 0x400)
     }
 }
 

--- a/sdl-ui/src/lib.rs
+++ b/sdl-ui/src/lib.rs
@@ -99,11 +99,11 @@ impl SDLUI {
         let cycles_per_interrupt = 50_000;
 
         let mut fps_timer = time::Instant::now();
-        loop {
+        'main_loop: loop {
             if !self.nes.borrow().has_cartridge() {
                 for event in event_pump.poll_iter() {
                     match event {
-                        SDL_Event::Quit { .. } => std::process::exit(0),
+                        SDL_Event::Quit { .. } => break 'main_loop,
                         _ => {}
                     }
                 }
@@ -113,7 +113,7 @@ impl SDLUI {
             if self.nes.borrow().paused {
                 for event in event_pump.poll_iter() {
                     match event {
-                        SDL_Event::Quit { .. } => std::process::exit(0),
+                        SDL_Event::Quit { .. } => break 'main_loop,
                         _ => {}
                     }
                 }
@@ -153,7 +153,7 @@ impl SDLUI {
             if self.nes.borrow().get_shift_strobe() || cycle_interrupt_timer == 0 {
                 for event in event_pump.poll_iter() {
                     match event {
-                        SDL_Event::Quit { .. } => std::process::exit(0),
+                        SDL_Event::Quit { .. } => break 'main_loop,
                         _ => {}
                     }
                 }
@@ -161,14 +161,14 @@ impl SDLUI {
                 let joy_x = controller.axis(Axis::LeftX);
                 let joy_y = controller.axis(Axis::LeftY);
                 let joy_input = vec![
-                    joy_x > DEAD_ZONE,                // Right
-                    joy_x < -DEAD_ZONE,               // Left
-                    joy_y > DEAD_ZONE,                // Down
-                    joy_y < -DEAD_ZONE,               // Up
-                    controller.button(Button::Start), // Start
-                    controller.button(Button::Back),  // Select
-                    controller.button(Button::B),     // B
-                    controller.button(Button::A),     // A
+                    joy_x > DEAD_ZONE || controller.button(Button::DPadRight), // Right
+                    joy_x < -DEAD_ZONE || controller.button(Button::DPadLeft), // Left
+                    joy_y > DEAD_ZONE || controller.button(Button::DPadDown),  // Down
+                    joy_y < -DEAD_ZONE || controller.button(Button::DPadUp),   // Up
+                    controller.button(Button::Start),                          // Start
+                    controller.button(Button::Back),                           // Select
+                    controller.button(Button::B),                              // B
+                    controller.button(Button::A),                              // A
                 ];
 
                 let mut controller_byte = 0;


### PR DESCRIPTION
- Added a pause feature
    - Available in the menubar on the Windows UI
    - Produces a semi-transparent gray overlay with a red pause logo
    - Not yet implemented on the SDL frontend, but it's implemented as a platform-independent feature of the game display
- Added controller support
    - Uses the SDL2 event pump
    - Joystick OR D-Pad OR arrow keys map to the NES D-Pad
        - The joystick handling allows for a deadzone
    - A, B, start, and select correspond to the Xbox controller layout
- Added a short delay before NMI, slightly improving test performance
- Fixed minor mapper bugs that resulted in breakage of some obscure games
- Made 4-screen mirroring work by minorly adjusting nametable memory logic
- Vastly improved iNES + NES 2.0 handling
    - They are now differentiated using the official standard (NES 2.0 marker bits) as well as heuristics to detect garbage such as "DiskDude!" >:(
    - Added better support for lots of features such as extended controllers and submappers
- Updated README