### PR TITLE
Improve audio sync with basic dynamic sampling

### DIFF
--- a/memory/src/rom.rs
+++ b/memory/src/rom.rs
@@ -24,9 +24,6 @@ impl Memory for ROM {
     }
 
     fn write(&mut self, addr: u16, data: u8) {
-        panic!(
-            "attempted to write {:X} to address {:X} in ROM",
-            data, addr
-        )
+        panic!("attempted to write {:X} to address {:X} in ROM", data, addr)
     }
 }

--- a/sdl-ui/src/lib.rs
+++ b/sdl-ui/src/lib.rs
@@ -198,6 +198,10 @@ impl SDLUI {
             // ceasing sampling while the device is above that threshold.
             let mut buff = self.nes.borrow_mut().take_audio_buff();
             if device.size() < AUDIO_BUFF_THRESHOLD as u32 {
+                // Simple volume attenuation, since there's no audio mixing implementation yet
+                for entry in buff.iter_mut() {
+                    *entry *= 0.25;
+                }
                 audio_buff.append(&mut buff);
             }
 


### PR DESCRIPTION
Adds a very basic dynamic sampling scheme based on that of http://github.com/ltriant/nes. This tries to maintain a small audio delay by preparing samples only when the queue is running low, and flushing these samples to the audio device queue each video frame.

Also attenuates volume to 25% (technically it's the amplitude being attenuated, which is different) as a stopgap for audio mixing.